### PR TITLE
Remove tox dependency and download docker-compose with curl

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,4 @@
 .git*
 .dockerignore
-.tox
-.ycp_playground
-.idea
 tests/
-acceptance/
 data/
-playground/

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,2 @@
-*.pyc
 *.sw[a-z]
-/.tox
-.cache
-.ycp_playground
-playground
-.idea
-pgctl.yaml
+bin/docker-compose*

--- a/Dockerfile.opensource
+++ b/Dockerfile.opensource
@@ -36,7 +36,7 @@ RUN dpkg -i dumb-init_*.deb
 
 RUN apt-get clean
 
-# We directly pin both lua and python dependencies to allow for reproducible
+# We directly pin both lua dependencies to allow for reproducible
 # deploy builds.
 RUN luarocks install lyaml 6.1.1-4
 RUN luarocks install luasocket 3.0rc1-2

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[tox]
-skipsdist = true
-tox_pip_extensions_ext_pip_custom_platform = true
-tox_pip_extensions_ext_venv_update = true
-
-[testenv:docker-compose]
-basepython = python3.6
-deps = docker-compose


### PR DESCRIPTION
We have a dependency on python, pip and tox which is quite useless. We only use tox to download docker-compose now, which is weird given that docker-compose is a statically linked go binary.

According to https://docs.docker.com/compose/install/#prerequisites you can simply use curl to get the binary and then use it.

I tested this on both linux and macos and works fine on both.