### PR TITLE
Always emit zipkin spans to syslog

### DIFF
--- a/itest/test/spectre/zipkin_test.py
+++ b/itest/test/spectre/zipkin_test.py
@@ -74,7 +74,7 @@ class TestZipkinLogging(object):
         assert backend_headers['x-b3-spanid'] != incoming_parent_id
         assert backend_headers['x-b3-spanid'] != incoming_span_id
 
-    def _assert_span_not_in_logs(self, trace_id, span_id, parent_span_id):
+    def _assert_no_span_in_logs(self):
         assert load_zipkin_spans(SYSLOG_FILE) == []
 
     def _check_span_logs(self, trace_id, span_id, parent_span_id, num_lines=1):
@@ -154,3 +154,11 @@ class TestZipkinLogging(object):
         # backend service to set it themselves.
         assert cached_response.headers['X-Zipkin-Id'] == trace_id
         self._check_span_logs(trace_id, span_id, parent_span_id, num_lines=2)
+
+    def test_dont_emit_span_if_no_headers(self, clean_log_files):
+        response = get_through_spectre(
+            '/not_cacheable',
+        )
+        assert response.status_code == 200
+
+        self._assert_no_span_in_logs()

--- a/itest/test/spectre/zipkin_test.py
+++ b/itest/test/spectre/zipkin_test.py
@@ -95,10 +95,10 @@ class TestZipkinLogging(object):
         self._call_with_zipkin(trace_id, span_id, parent_span_id, sampled='1')
         self._check_span_logs(trace_id, span_id, parent_span_id)
 
-    def test_doesnt_log_if_not_sampled(self, clean_log_files):
+    def test_still_log_even_if_not_sampled(self, clean_log_files):
         trace_id, span_id, parent_span_id = self._get_random_zipkin_ids()
         self._call_with_zipkin(trace_id, span_id, parent_span_id, sampled='0')
-        self._assert_span_not_in_logs(trace_id, span_id, parent_span_id)
+        self._check_span_logs(trace_id, span_id, parent_span_id)
 
     def test_propagates_zipkin_headers(self, clean_log_files):
         """Make sure Spectre passes properly transformed Zipkin headers

--- a/lua/zipkin.lua
+++ b/lua/zipkin.lua
@@ -65,15 +65,13 @@ function zipkin.inject_zipkin_headers(incoming_zipkin_headers)
     return headers
 end
 
--- If Zipkin headers exist, then log them to syslog.
--- Start and end times are in epoch seconds, but Zipkin wants them in
--- microseconds.
+-- If Zipkin headers exist, then log them to syslog. X-B3-Flags and X-B3-Sampled
+-- are optional in the Zipkin spec, so we'll emit a '-' if they're not present.
+-- Start and end times are in epoch seconds, but Zipkin wants them in microseconds.
 function zipkin.emit_syslog(headers, start_time, end_time)
     if headers['X-B3-TraceId'] ~= nil and
             headers['X-B3-SpanId'] ~= nil and
-            headers['X-B3-ParentSpanId'] ~= nil and
-            headers['X-B3-Flags'] ~= nil and
-            headers['X-B3-Sampled'] ~= nil then
+            headers['X-B3-ParentSpanId'] ~= nil then
 
         local request_string = string.format('"%s %s %s"',
             ngx.var.request_method,
@@ -86,8 +84,8 @@ function zipkin.emit_syslog(headers, start_time, end_time)
             headers['X-B3-TraceId'],
             headers['X-B3-SpanId'],
             headers['X-B3-ParentSpanId'],
-            headers['X-B3-Flags'],
-            headers['X-B3-Sampled'],
+            headers['X-B3-Flags'] or '-',
+            headers['X-B3-Sampled'] or '-',
             start_time * 1000000,
             end_time * 1000000,
             ngx.var.remote_addr,

--- a/lua/zipkin.lua
+++ b/lua/zipkin.lua
@@ -70,36 +70,34 @@ end
 -- microseconds.
 function zipkin.emit_syslog(headers, start_time, end_time)
     local sampled = headers['X-B3-Sampled']
-    if sampled == '1' then
-        local request_string = string.format('"%s %s %s"',
-            ngx.var.request_method,
-            ngx.var.request_uri,
-            ngx.var.server_protocol
+    local request_string = string.format('"%s %s %s"',
+        ngx.var.request_method,
+        ngx.var.request_uri,
+        ngx.var.server_protocol
 	)
-        local message = string.format(
-            'spectre/zipkin %s %s %s %s %s %d %d, client: %s, server: , request: %s',
-            headers['X-B3-TraceId'],
-            headers['X-B3-SpanId'],
-            headers['X-B3-ParentSpanId'],
-            headers['X-B3-Flags'],
-            sampled,
-            start_time * 1000000,
-            end_time * 1000000,
-            ngx.var.remote_addr,
-            request_string
-        )
+    local message = string.format(
+        'spectre/zipkin %s %s %s %s %s %d %d, client: %s, server: , request: %s',
+        headers['X-B3-TraceId'],
+        headers['X-B3-SpanId'],
+        headers['X-B3-ParentSpanId'],
+        headers['X-B3-Flags'],
+        sampled,
+        start_time * 1000000,
+        end_time * 1000000,
+        ngx.var.remote_addr,
+        request_string
+    )
 
 	-- RFC5424 is the syslog format. We encode the message and send it along to syslog2scribe
-        local encoded_message = rfc5424.encode(
-           "LOCAL0",
-           "INFO",
-           ngx.var.hostname,
-           ngx.var.pid,
-           "nginx_spectre",
-           message
-        )
-        sock:send(encoded_message)
-    end
+    local encoded_message = rfc5424.encode(
+        "LOCAL0",
+        "INFO",
+        ngx.var.hostname,
+        ngx.var.pid,
+        "nginx_spectre",
+        message
+    )
+    sock:send(encoded_message)
 end
 
 return zipkin


### PR DESCRIPTION
We've updated syslog2scribe to support firehose mode, so we now need to always send the zipkin span to it.