### PR TITLE
fix caching with id extraction enabled

### DIFF
--- a/itest/data/srv-configs/backend.main.yaml
+++ b/itest/data/srv-configs/backend.main.yaml
@@ -2,15 +2,44 @@ uncacheable_headers:
     - 'Uncacheable-Header'
 
 cached_endpoints:
-    timestamp: {ttl: 2, pattern: '^/timestamp/.*$', vary_headers: ['X-Mode', 'accept-encoding']}
-    long_ttl: {ttl: 30, pattern: '^/long_ttl/.*$'}
-    gzipped_response: {ttl: 2, pattern: '^/gzipped$'}
-    happy_cache: {ttl: 10, pattern: '^/happy/\\?.*$'}
-      # bulk endpoint caching regex
-    get_user_info: {ttl: 30, pattern: "^/get_user_info/v1(\\?|\\?.*&)ids=[0-9]+(&.*$|$)"}
-    bulk_requester_does_not_cache_missing_ids: {ttl: 30, pattern: "(^/bulk_requester(?:\\?|\\?.*&)ids=)((?:\\S|%2C)+)(.*$)", bulk_support: true, id_identifier: 'bulk_id', dont_cache_missing_ids: true}
-    bulk_requester_default: {ttl: 30, pattern: "(^/bulk_requester_2/)((?:\\d|,)+)(/v1.*$)", bulk_support: true, id_identifier: 'bulk_id'}
-    forbidden: {ttl: 30, pattern: "(^/not_authorized\\?ids=)((?:\\d|%2C)+)(.*$)", bulk_support: true, id_identifier: 'id'}
+    timestamp:
+        pattern: '^/timestamp/.*$'
+        ttl: 2
+        vary_headers: ['X-Mode', 'accept-encoding']
+    long_ttl:
+        pattern: '^/long_ttl/.*$'
+        ttl: 30
+    gzipped_response:
+        pattern: '^/gzipped$'
+        ttl: 2
+    happy_cache:
+        pattern: '^/happy/\\?.*$'
+        ttl: 10
+    get_user_info:
+        pattern: "^/get_user_info/v1(\\?|\\?.*&)ids=[0-9]+(&.*$|$)"
+        ttl: 30
+    url_with_id_extraction:
+        pattern: "^/biz\\?(?:.*&)?business_id=(\\d+)(?:&.*$|$)"
+        ttl: 30
+        enable_invalidation: true
+    # bulk endpoint caching regex
+    bulk_requester_does_not_cache_missing_ids:
+        bulk_support: true
+        dont_cache_missing_ids: true
+        id_identifier: 'bulk_id'
+        pattern: "(^/bulk_requester(?:\\?|\\?.*&)ids=)((?:\\S|%2C)+)(.*$)"
+        ttl: 30
+    bulk_requester_default:
+        bulk_support: true
+        id_identifier: 'bulk_id'
+        pattern: "(^/bulk_requester_2/)((?:\\d|,)+)(/v1.*$)"
+        ttl: 30
+    forbidden:
+        bulk_support: true
+        id_identifier: 'id'
+        pattern: "(^/not_authorized\\?ids=)((?:\\d|%2C)+)(.*$)"
+        ttl: 30
+
 # Default Vary headers. Can be overridden by pattern specific Vary headers
 vary_headers:
     - 'Accept-Encoding'

--- a/itest/data/srv-configs/backend.main.yaml
+++ b/itest/data/srv-configs/backend.main.yaml
@@ -21,7 +21,7 @@ cached_endpoints:
     url_with_id_extraction:
         pattern: "^/biz\\?(?:.*&)?business_id=(\\d+)(?:&.*$|$)"
         ttl: 30
-        enable_invalidation: true
+        enable_id_extraction: true
     # bulk endpoint caching regex
     bulk_requester_does_not_cache_missing_ids:
         bulk_support: true

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -184,6 +184,24 @@ class TestGetMethod(object):
         assert response.text == 'Error requesting /timestamp/cached?drop_connection=true: closed'
         assert response.status_code == 502
 
+    def test_caching_works_with_id_extraction(self):
+        response = get_through_spectre('/biz?foo=bar&business_id=1234')
+        assert response.headers['Spectre-Cache-Status'] == 'miss'
+
+        # ensure extracting the id is not messing up the caching logic
+        assert_is_in_spectre_cache('/biz?foo=bar&business_id=1234')
+
+        # check that invalidation is actually supported
+        purge_resource({
+            'namespace': 'backend.main',
+            'cache_name': 'url_with_id_extraction',
+            'id': '1234',
+        })
+
+        # now this should be a cache miss
+        response = get_through_spectre('/biz?foo=bar&business_id=1234')
+        assert response.headers['Spectre-Cache-Status'] == 'miss'
+
 
 class TestPostMethod(object):
 

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -18,7 +18,7 @@ end
 -- Callback to save response to cache, to be executed after the response has been sent
 function caching_handlers._post_request_callback(response, request_info, cacheability_info)
     local ids = {'null'}
-    if cacheability_info.enable_invalidation then
+    if cacheability_info.enable_id_extraction then
         ids = caching_handlers._extract_ids_from_uri(
             request_info.normalized_uri,
             cacheability_info.pattern
@@ -49,7 +49,7 @@ end
 -- Respond to requests for caching normal endpoints (non-bulk)
 function caching_handlers._caching_handler(request_info, cacheability_info)
     local id = 'null'
-    if cacheability_info.enable_invalidation then
+    if cacheability_info.enable_id_extraction then
         id = caching_handlers._extract_ids_from_uri(
             request_info.normalized_uri,
             cacheability_info.pattern

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -48,10 +48,18 @@ end
 
 -- Respond to requests for caching normal endpoints (non-bulk)
 function caching_handlers._caching_handler(request_info, cacheability_info)
+    local id = 'null'
+    if cacheability_info.enable_invalidation then
+        id = caching_handlers._extract_ids_from_uri(
+            request_info.normalized_uri,
+            cacheability_info.pattern
+        )[1]
+    end
+
     -- Check if datastore already has url cached
     local cached_value = spectre_common.fetch_from_cache(
         cassandra_helper,
-        'null',
+        id,
         request_info.normalized_uri,
         request_info.destination,
         cacheability_info.cache_name,

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -102,7 +102,7 @@ local function determine_if_cacheable(url, namespace, request_headers)
                 bulk_support = cache_entry['bulk_support'],
                 id_identifier = cache_entry['id_identifier'],
                 dont_cache_missing_ids = cache_entry['dont_cache_missing_ids'],
-                enable_invalidation = cache_entry['enable_invalidation'],
+                enable_id_extraction = cache_entry['enable_id_extraction'],
                 refresh_cache = false,
                 num_buckets = cache_entry['buckets'],
             }

--- a/tests/lua/caching_handlers_test.lua
+++ b/tests/lua/caching_handlers_test.lua
@@ -139,7 +139,7 @@ insulate('caching_handlers', function()
                 },
                 {
                     cache_name = 'test_cache',
-                    enable_invalidation = true,
+                    enable_id_extraction = true,
                     pattern = '^/uri\\?ids=((?:\\d|%2C)+)&.*$',
                     ttl = 10,
                     num_buckets = 500,


### PR DESCRIPTION
When id extraction (for invalidation) is enabled for normal endpoints, we need to do it both when reading and writing. Otherwise `get_bucket` returns inconsistent values and we end up with 100% cache misses even if you keep asking for the same url. Fixes #14 

Added new itest to cover this issue. Was failing with the old code, passing now.