### PR TITLE
Ignore the fact casper.internal is not in services.yaml

### DIFF
--- a/itest/test/spectre/internal_spectre_test.py
+++ b/itest/test/spectre/internal_spectre_test.py
@@ -41,6 +41,6 @@ class TestConfigs(object):
         assert status['smartstack_configs'] == {
             u'backend.main': {u'host': u'10.5.0.3', u'port': 9080},
         }
-        # services.yaml and backend.main.yaml
-        assert len(status['mod_time_table']) == 2
+        # services.yaml, backend.main.yaml and casper.internal.yaml
+        assert len(status['mod_time_table']) == 3
         assert isinstance(status['worker_id'], int)

--- a/lua/config_loader.lua
+++ b/lua/config_loader.lua
@@ -176,5 +176,7 @@ return {
     get_spectre_config_for_namespace = get_spectre_config_for_namespace,
     set_spectre_config_for_namespace = set_spectre_config_for_namespace,
     get_all_spectre_configs = get_all_spectre_configs,
-    has_spectre_configs = has_spectre_configs
+    has_spectre_configs = has_spectre_configs,
+
+    CASPER_INTERNAL_NAMESPACE = CASPER_INTERNAL_NAMESPACE,
 }

--- a/lua/config_loader.lua
+++ b/lua/config_loader.lua
@@ -4,6 +4,7 @@ local util = require 'util'
 
 local SRV_CONFIGS_PATH = os.getenv('SRV_CONFIGS_PATH')
 local SERVICES_YAML_PATH = os.getenv('SERVICES_YAML_PATH')
+local CASPER_INTERNAL_NAMESPACE = 'casper.internal'
 
 local RELOAD_DELAY = 30  -- seconds
 

--- a/lua/internal_handlers.lua
+++ b/lua/internal_handlers.lua
@@ -76,7 +76,7 @@ local function status_handler(_)
     for namespace in pairs(config_loader.get_all_spectre_configs()) do
         if namespace ~= 1 then
             local info = config_loader.get_smartstack_info_for_namespace(namespace)
-            if info == nil then
+            if info == nil and namespace ~= config_loader.CASPER_INTERNAL_NAMESPACE then
                 proxied_services[namespace] = 'missing'
                 status = ngx.HTTP_INTERNAL_SERVER_ERROR
             else


### PR DESCRIPTION
`casper.internal` is a reserved namespace and doesn't need to be in services.yaml