### PR TITLE
Rewrite SIGTERM to SIGQUIT to let nginx shutdown gracefully

### DIFF
--- a/Dockerfile.opensource
+++ b/Dockerfile.opensource
@@ -64,5 +64,7 @@ RUN mkdir -p /var/log/nginx
 RUN chown -R nobody:nogroup /var/log/nginx
 
 USER nobody
-CMD ["dumb-init", "/code/start.sh"]
+
+# Rewrite SIGTERM(15) to SIGQUIT(3) to let Nginx shut down gracefully
+CMD ["dumb-init", "--rewrite", "15:3", "/code/start.sh"]
 # vim: syntax=dockerfile


### PR DESCRIPTION
This resolves #21. Since we have our own internal Dockerfile I'll mirror this internally once this PR gets approved.