### PR TITLE
Bake cassandra schema in docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ itest: clean-docker $(DOCKER_COMPOSE) cook-image run-itest
 run-itest: $(DOCKER_COMPOSE)
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) build
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) up -d spectre backend cassandra syslog
-	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) exec -T cassandra /opt/setup.sh
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) run test python -m pytest -vv spectre
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) exec --user=root -T spectre /opt/drop_all.sh
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) run test python -m pytest -vv cassandra

--- a/itest/cassandra/Dockerfile
+++ b/itest/cassandra/Dockerfile
@@ -40,4 +40,7 @@ RUN     chown -R dckruser /nail/cassandra/
 RUN     echo "JVM_OPTS=\"\$JVM_OPTS -Dcassandra.skip_wait_for_gossip_to_settle=0\"" >> /etc/cassandra/cassandra-env.sh
 
 USER    dckruser
+
+# Creates cassandra keyspace and tables
+RUN     cassandra && /opt/setup.sh
 CMD     ["dumb-init", "cassandra", "-f"]

--- a/itest/cassandra/Dockerfile
+++ b/itest/cassandra/Dockerfile
@@ -43,4 +43,7 @@ USER    dckruser
 
 # Creates cassandra keyspace and tables
 RUN     cassandra && /opt/setup.sh
+
+# CMD only provides a default command to run when you start a container from this image.
+# It doesn't get executed during the build, so the 2 cassandra processes won't conflict.
 CMD     ["dumb-init", "cassandra", "-f"]

--- a/itest/cassandra/spectre_db.cache_store.cql
+++ b/itest/cassandra/spectre_db.cache_store.cql
@@ -5,12 +5,9 @@ CREATE TABLE spectre_db.cache_store (
     id text,
     key text,
     vary_headers text,
-    id_set set<text>,
     body blob,
     headers text,
     PRIMARY KEY ((bucket, namespace, cache_name), id, key, vary_headers)
 ) WITH
     compaction = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'};
-
-CREATE INDEX cache_store_id_set_index ON spectre_db.cache_store (id_set);

--- a/itest/test/spectre/internal_spectre_test.py
+++ b/itest/test/spectre/internal_spectre_test.py
@@ -1,13 +1,33 @@
 # -*- coding: utf-8 -*-
 import json
+import time
+
+import pytest
 
 from util import get_from_spectre
 from util import get_through_spectre
 
 
+@pytest.fixture(scope='module')
+def wait_for_casper():
+    """ Wait for casper and cassandra to be ready.
+
+    It takes a bit for casper and cassandra to be ready to serve requests,
+    while the tests usually start immediately without waiting.
+    """
+    for i in range(30):
+        response = get_from_spectre('/status')
+        if response.status_code == 200:
+            return
+        else:
+            time.sleep(1)
+    else:
+        raise RuntimeError("Spectre was not ready after 30 seconds")
+
+
 class TestCanReachStatuses(object):
 
-    def test_can_reach_spectre_status(self):
+    def test_can_reach_casper_status(self, wait_for_casper):
         response = get_through_spectre('/status')
         assert response.status_code == 200
         assert response.text == 'Backend is alive\n'
@@ -28,7 +48,7 @@ class TestCanReachStatuses(object):
 
 class TestConfigs(object):
 
-    def test_can_get_spectre_configs(self):
+    def test_can_get_casper_configs(self, wait_for_casper):
         response = get_from_spectre('/configs')
         assert response.status_code == 200
         status = json.loads(response.text)


### PR DESCRIPTION
This greatly simplifies our task in acceptance tests since the cassandra docker image will be already ready and we won't have to create the schema manually.

I also removed the id_set column and index that we no longer use.