### PR TITLE
Use config file for everything

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,13 +1,9 @@
 daemon off;
 
-env HTTP_TIMEOUT_MS;
-env METEORITE_WORKER_PORT;
 env PAASTA_INSTANCE;
 env PAASTA_SERVICE;
 env SERVICES_YAML_PATH;
 env SRV_CONFIGS_PATH;
-env SYSLOG_HOST;
-env SYSLOG_PORT;
 
 events {
     worker_connections 4096;

--- a/itest/data/srv-configs/casper.internal.yaml
+++ b/itest/data/srv-configs/casper.internal.yaml
@@ -3,9 +3,25 @@ cassandra:
     connect_timeout_ms: 500
     default_num_buckets: 1000
     keyspace: 'spectre_db'
+    local_dc: 'norcal-devc'
     local_region: '.*'
     num_retries: 3
     read_timeout_ms: 100
     retry_on_timeout: false
     write_consistency: 'all'
     write_timeout_ms: 1000
+
+http:
+    # Lower http timeout to test that we return a 504 on timeouts
+    timeout_ms: 1000
+
+yelp_meteorite:
+    etc_path: '/code/itest/data/etc'
+    metrics-relay:
+        host: '127.0.0.1'
+        port: 1234
+
+zipkin:
+    syslog:
+        host: '10.5.0.6'
+        port: 514

--- a/itest/docker-compose.yml
+++ b/itest/docker-compose.yml
@@ -8,17 +8,11 @@ services:
         depends_on:
             - syslog
         environment:
-            - ITEST=1
-            - MARATHON_HOST=itest_host
             - PAASTA_SERVICE=spectre
             - PAASTA_INSTANCE=itest
             - SRV_CONFIGS_PATH=/code/itest/data/srv-configs
             - SERVICES_YAML_PATH=/code/itest/data/services.yaml
             - WORKER_PROCESSES=1
-            # Lower http timeout to test that we return a 504 on timeouts
-            - HTTP_TIMEOUT_MS=1000
-            - SYSLOG_HOST=10.5.0.6
-            - SYSLOG_PORT=514
         volumes:
             - /var/log/nginx
             - ./data/etc:/nail/etc:ro

--- a/lua/datastores.lua
+++ b/lua/datastores.lua
@@ -94,7 +94,7 @@ function cassandra_helper.create_cluster(cluster_module, shm, timeout)
     local hosts = cassandra_helper.get_cluster_hosts()
     spectre_common.log(ngx.WARN, { err='init ' .. shm .. ' cluster with timeout ' .. timeout, critical=false })
     -- Use datacenter-aware load balancing policy
-    local dc_name = metrics_helper.get_system_dimension('superregion')
+    local dc_name = configs['local_dc']
     local cluster, err = cluster_module.new {
         shm = shm,
         contact_points = hosts,

--- a/lua/http.lua
+++ b/lua/http.lua
@@ -1,11 +1,11 @@
+local config_loader = require 'config_loader'
 local http = require "resty.http"
 
--- This timeout should match the one in yelpsoa-configs:spectre/smartstack.yaml
-local HTTP_TIMEOUT = os.getenv('HTTP_TIMEOUT_MS') or 60000 -- ms
 
 local function make_http_request(method, uri, headers)
+    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['http']
     local httpc = http.new()
-    httpc:set_timeout(HTTP_TIMEOUT)
+    httpc:set_timeout(configs['timeout_ms'])
 
     local client_body_reader, _ = httpc:get_client_body_reader()
 

--- a/start.sh
+++ b/start.sh
@@ -3,9 +3,6 @@
 SRV_CONFIGS_PATH=${SRV_CONFIGS_PATH:-/nail/srv/configs/spectre}
 SERVICES_YAML_PATH=${SERVICES_YAML_PATH:-/nail/etc/services/services.yaml}
 CASSANDRA_CLUSTER_CONFIG=${CASSANDRA_CLUSTER_CONFIG:-/var/run/synapse/services/cassandra_spectre.main.json}
-SYSLOG_HOST=${SYSLOG_HOST:-169.254.255.254}
-SYSLOG_PORT=${SYSLOG_PORT:-1514}
-METEORITE_WORKER_PORT=${METEORITE_WORKER_PORT:-$(cat /nail/etc/services/statsite/port)}
 # We run 1 worker per container in production
 WORKER_PROCESSES=${WORKER_PROCESSES:-1}
 
@@ -17,11 +14,6 @@ fi
 
 SRV_CONFIGS_PATH=$SRV_CONFIGS_PATH \
     SERVICES_YAML_PATH=$SERVICES_YAML_PATH \
-    CASSANDRA_CLUSTER_CONFIG=$CASSANDRA_CLUSTER_CONFIG \
-    METEORITE_WORKER_PORT=$METEORITE_WORKER_PORT \
-    SYSLOG_HOST=$SYSLOG_HOST \
-    SYSLOG_PORT=$SYSLOG_PORT \
-    HTTP_TIMEOUT_MS=$HTTP_TIMEOUT_MS \
     /usr/local/openresty/nginx/sbin/nginx \
         -c /code/config/nginx.conf \
         -g "worker_processes $WORKER_PROCESSES;"

--- a/tests/data/srv-configs/casper.internal.yaml
+++ b/tests/data/srv-configs/casper.internal.yaml
@@ -3,9 +3,24 @@ cassandra:
     connect_timeout_ms: 100
     default_num_buckets: 1000
     keyspace: 'spectre_db'
+    local_dc: 'norcal-devc'
     local_region: '.*'
     num_retries: 3
     read_timeout_ms: 15
     retry_on_timeout: false
     write_consistency: 'all'
     write_timeout_ms: 1000
+
+http:
+    timeout_ms: 10000
+
+yelp_meteorite:
+    etc_path: '/code/tests/data/etc'
+    metrics-relay:
+        host: 127.0.0.1
+        port: 1234
+
+zipkin:
+    syslog:
+        host: 127.0.0.1
+        port: 514

--- a/tests/lua/metrics_helper_test.lua
+++ b/tests/lua/metrics_helper_test.lua
@@ -1,98 +1,90 @@
 require 'busted.runner'()
 
-insulate("overriding io.open and os.getenv", function()
+describe("metrics_helper", function()
+    local config_loader
 
-    describe("metrics_helper", function()
-        setup(function()
-            _G.os.getenv = function(e)
-                return e
+    setup(function()
+        config_loader = require 'config_loader'
+        config_loader.load_services_configs('/code/tests/data/srv-configs')
+        configs = config_loader.get_spectre_config_for_namespace('casper.internal')['yelp_meteorite']
+
+        stub(ngx, 'log')
+    end)
+
+    before_each(function()
+        -- unload metrics_helper before every test to begin clean
+        _G.package.loaded.metrics_helper = nil
+
+        -- override socket lib so that we don't actually transmit data
+        _G.package.loaded.socket = {
+            udp = function(e)
+                return {
+                    setsockname = function() end,
+                    setpeername = function() end,
+                    send = function() end,
+                }
             end
+        }
+    end)
 
-            local old_open = _G.io.open
-            _G.io.open = function(name, mode)
-                if string.match(name, '/nail/etc/') then
-                    return {
-                        read = function(_)
-                            return string.match(name, ".+/(.*)")
-                        end
-                    }
-                else
-                    return old_open(name, mode)
-                end
+    it("calls and initializes the UDP socket only once", function()
+        local spy_setsockname = spy(function() end)
+        local spy_setpeername = spy(function() end)
+
+        _G.package.loaded.socket = {
+            udp = function(e)
+                return {
+                    setsockname = spy_setsockname,
+                    setpeername = spy_setpeername,
+                }
             end
+        }
+        spy.on(_G.package.loaded.socket, 'udp')
 
-            stub(ngx, 'log')
-        end)
+        local metrics_helper = require 'metrics_helper'
+        metrics_helper._get_sock()
+        metrics_helper._get_sock()
 
-        before_each(function()
-            -- unload metrics_helper before every test to begin clean
-            _G.package.loaded.metrics_helper = nil
+        assert.spy(_G.package.loaded.socket.udp).was.called(1)
+        assert.spy(spy_setsockname).was.called_with(match._, "*", 0)
+        assert.spy(spy_setpeername).was.called_with(
+            match._,
+            configs['metrics-relay']['host'],
+            configs['metrics-relay']['port']
+        )
+    end)
 
-            -- override socket lib so that we don't actually transmit data
-            _G.package.loaded.socket = {
-                udp = function(e)
-                    return {
-                        setsockname = function() end,
-                        setpeername = function() end,
-                        send = function() end,
-                    }
-                end
-            }
-        end)
+    it("emit_request_timing sends data to metrics_relay via UDP", function()
+        local spy_send = spy(function() end)
 
-        it("calls and initializes the UDP socket only once", function()
-            local spy_setsockname = spy(function() end)
-            local spy_setpeername = spy(function() end)
+        _G.package.loaded.socket = {
+            udp = function(e)
+                return {
+                    setsockname = function() end,
+                    setpeername = function() end,
+                    send = spy_send,
+                }
+            end
+        }
 
-            _G.package.loaded.socket = {
-                udp = function(e)
-                    return {
-                        setsockname = spy_setsockname,
-                        setpeername = spy_setpeername,
-                    }
-                end
-            }
-            spy.on(_G.package.loaded.socket, 'udp')
+        local metrics_helper = require 'metrics_helper'
+        metrics_helper.emit_request_timing(1, 'some.namespace', 'test_cache', 200)
 
-             local metrics_helper = require 'metrics_helper'
-
-            assert.spy(_G.package.loaded.socket.udp).was.called(1)
-            assert.spy(spy_setsockname).was.called_with(match._, "*", 0)
-            assert.spy(spy_setpeername).was.called_with(match._, "169.254.255.254", "METEORITE_WORKER_PORT")
-        end)
-
-        it("emit_request_timing sends data to metrics_relay via UDP", function()
-            local spy_send = spy(function() end)
-
-            _G.package.loaded.socket = {
-                udp = function(e)
-                    return {
-                        setsockname = function() end,
-                        setpeername = function() end,
-                        send = spy_send,
-                    }
-                end
-            }
-
-            local metrics_helper = require 'metrics_helper'
-            metrics_helper.emit_request_timing(1, 'some.namespace', 'test_cache', 200)
-
-           assert.are_equal(
-               '[["habitat", "habitat"],["service_name", "PAASTA_SERVICE"],["instance_name", "PAASTA_INSTANCE"],["namespace", "some.namespace"],["cache_name", "test_cache"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
-               spy_send.calls[1]['vals'][2] -- 2nd argument of the first call
-           )
-           assert.are_equal(
-               '[["habitat", "habitat"],["service_name", "PAASTA_SERVICE"],["instance_name", "PAASTA_INSTANCE"],["namespace", "__ALL__"],["cache_name", "test_cache"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
-               spy_send.calls[2]['vals'][2] -- 2nd argument of the second call
-           )
-           assert.are_equal(
-               '[["habitat", "habitat"],["service_name", "PAASTA_SERVICE"],["instance_name", "PAASTA_INSTANCE"],["namespace", "some.namespace"],["cache_name", "__ALL__"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
-               spy_send.calls[3]['vals'][2] -- 2nd argument of the third call
-           )
-           assert.are_equal(
-               '[["habitat", "habitat"],["service_name", "PAASTA_SERVICE"],["instance_name", "PAASTA_INSTANCE"],["namespace", "__ALL__"],["cache_name", "__ALL__"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
-               spy_send.calls[4]['vals'][2] -- 2nd argument of the fourth call
-           )
-        end)
+        assert.are_equal(
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "some.namespace"],["cache_name", "test_cache"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
+            spy_send.calls[1]['vals'][2] -- 2nd argument of the first call
+        )
+        assert.are_equal(
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "__ALL__"],["cache_name", "test_cache"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
+            spy_send.calls[2]['vals'][2] -- 2nd argument of the second call
+        )
+        assert.are_equal(
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "some.namespace"],["cache_name", "__ALL__"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
+            spy_send.calls[3]['vals'][2] -- 2nd argument of the third call
+        )
+        assert.are_equal(
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "__ALL__"],["cache_name", "__ALL__"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
+            spy_send.calls[4]['vals'][2] -- 2nd argument of the fourth call
+        )
     end)
 end)

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -1,13 +1,9 @@
 require 'busted.runner'()
 
-insulate("overriding os.getenv", function()
+describe("spectre_common", function()
     local config_loader, spectre_common
 
     setup(function()
-        _G.os.getenv = function(e)
-            return e
-        end
-
         _G.package.loaded.socket = {
             dns = {
                 toip = function(_)
@@ -24,6 +20,7 @@ insulate("overriding os.getenv", function()
         }
 
         config_loader = require 'config_loader'
+        config_loader.load_services_configs('/code/tests/data/srv-configs')
         spectre_common = require 'spectre_common'
 
         stub(ngx, 'log')

--- a/tests/lua/zipkin_test.lua
+++ b/tests/lua/zipkin_test.lua
@@ -1,82 +1,80 @@
 require 'busted.runner'()
 
-insulate("override os.getenv", function()
-    describe("zipkin", function()
-        local zipkin
+describe("zipkin", function()
+    local config_loader
+    local zipkin
 
-        setup(function()
-            _G.os.getenv = function(e)
-                return e
-            end
+    setup(function()
+        zipkin = require 'zipkin'
 
-            zipkin = require 'zipkin'
+        config_loader = require 'config_loader'
+        config_loader.load_services_configs('/code/tests/data/srv-configs')
 
-            stub(ngx, 'log')
-        end)
-
-        describe("random_string", function()
-            it("generates a random string of 16 characters", function()
-                local random_string = zipkin.random_string()
-                assert.equals(string.len(random_string), 16)
-            end)
-        end)
-
-        describe("get_new_headers", function()
-            it("correctly modifies zipkin headers when span ID exists", function()
-                local headers = {
-                    ['X-B3-SpanId'] = 'abc'
-                }
-                local new_headers = zipkin.get_new_headers(headers)
-
-                assert.equals(string.len(new_headers['X-B3-SpanId']), 16)
-                assert.equals(new_headers['X-B3-ParentSpanId'], 'abc')
-            end)
-
-            it("does no-op when zipkin headers not present", function()
-                local headers = {}
-                local new_headers = zipkin.get_new_headers(headers)
-
-                assert.is_nil(new_headers['X-B3-SpanId'])
-                assert.is_nil(new_headers['X-B3-ParentSpanId'])
-            end)
-        end)
-
-        describe("extract_zipkin_headers", function()
-            it("gets incoming zipkin headers", function()
-                -- Checks that extract_zipkin_headers creates a headers table with only
-                -- Zipkin-related headers.
-                local request_headers = {
-                    ['X-B3-TraceId'] = 'abc',
-                    ['X-B3-SpanId'] = 'bce',
-                    ['X-B3-ParentSpanId'] = 'ced',
-                    ['X-B3-Flags'] = '0',
-                    ['X-B3-Sampled'] = '1',
-                    ['Accept'] = 'text/plain',
-                    ['X-B3-Cookie-Monster'] = 'yum'
-                }
-                local headers = zipkin.extract_zipkin_headers(request_headers)
-                -- Lua doesn't have an easy way to get the # of entries in a table if
-                -- the table doesn't have consecutive integer keys (i.e. is an array).
-                local count = 0
-                for _ in pairs(headers) do
-                    count = count + 1
-                end
-                assert.equals(count, #zipkin['ZIPKIN_HEADERS'])
-                for index=1, #zipkin['ZIPKIN_HEADERS'] do
-                    local header = zipkin.ZIPKIN_HEADERS[index]
-                    assert.equals(headers[header], request_headers[header])
-                end
-            end)
-
-            it("doesn't add non-Zipkin headers", function()
-                local request_headers = {
-                    ['Accept'] = 'text/plain',
-                    ['X-B3-Cookie-Monster'] = 'yum'
-                }
-                local headers = zipkin.extract_zipkin_headers(request_headers)
-                assert.equals(next(headers), nil)
-            end)
-        end)
-
+        stub(ngx, 'log')
     end)
+
+    describe("random_string", function()
+        it("generates a random string of 16 characters", function()
+            local random_string = zipkin.random_string()
+            assert.equals(string.len(random_string), 16)
+        end)
+    end)
+
+    describe("get_new_headers", function()
+        it("correctly modifies zipkin headers when span ID exists", function()
+            local headers = {
+                ['X-B3-SpanId'] = 'abc'
+            }
+            local new_headers = zipkin.get_new_headers(headers)
+
+            assert.equals(string.len(new_headers['X-B3-SpanId']), 16)
+            assert.equals(new_headers['X-B3-ParentSpanId'], 'abc')
+        end)
+
+        it("does no-op when zipkin headers not present", function()
+            local headers = {}
+            local new_headers = zipkin.get_new_headers(headers)
+
+            assert.is_nil(new_headers['X-B3-SpanId'])
+            assert.is_nil(new_headers['X-B3-ParentSpanId'])
+        end)
+    end)
+
+    describe("extract_zipkin_headers", function()
+        it("gets incoming zipkin headers", function()
+            -- Checks that extract_zipkin_headers creates a headers table with only
+            -- Zipkin-related headers.
+            local request_headers = {
+                ['X-B3-TraceId'] = 'abc',
+                ['X-B3-SpanId'] = 'bce',
+                ['X-B3-ParentSpanId'] = 'ced',
+                ['X-B3-Flags'] = '0',
+                ['X-B3-Sampled'] = '1',
+                ['Accept'] = 'text/plain',
+                ['X-B3-Cookie-Monster'] = 'yum'
+            }
+            local headers = zipkin.extract_zipkin_headers(request_headers)
+            -- Lua doesn't have an easy way to get the # of entries in a table if
+            -- the table doesn't have consecutive integer keys (i.e. is an array).
+            local count = 0
+            for _ in pairs(headers) do
+                count = count + 1
+            end
+            assert.equals(count, #zipkin['ZIPKIN_HEADERS'])
+            for index=1, #zipkin['ZIPKIN_HEADERS'] do
+                local header = zipkin.ZIPKIN_HEADERS[index]
+                assert.equals(headers[header], request_headers[header])
+            end
+        end)
+
+        it("doesn't add non-Zipkin headers", function()
+            local request_headers = {
+                ['Accept'] = 'text/plain',
+                ['X-B3-Cookie-Monster'] = 'yum'
+            }
+            local headers = zipkin.extract_zipkin_headers(request_headers)
+            assert.equals(next(headers), nil)
+        end)
+    end)
+
 end)


### PR DESCRIPTION
Removes remaining env variables and uses the config file for all modules. The only env variables left are `SRV_CONFIGS_PATH`, `SERVICES_YAML_PATH`, `PAASTA_SERVICE` and `PAASTA_INSTANCE`.

We can't create sockets at import time anymore since at that point the config file hasn't been loaded yet, so I changed them to be singletons. It's cleaner anyway.