### PR TITLE
Emit hit_rate metric

### DIFF
--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -404,6 +404,7 @@ local function fetch_from_cache(cassandra_helper, id, uri, destination, cache_na
     local cache_status = cached_value['body'] ~= nil and 'hit' or 'miss'
     local dims = {{'namespace', destination}, {'cache_name', cache_name}, {'cache_status', cache_status}}
     metrics_helper.emit_timing('spectre.fetch_body_and_headers', (socket.gettime() - start_time) * 1000, dims)
+    metrics_helper.emit_counter('spectre.hit_rate', dims)
 
     return cached_value
 end


### PR DESCRIPTION
Our metrics have been weird since we dropped the hostname dimension. It looks like statsd isn't able to properly count the number of timers we send.

On the other hand, `spectre.bulk_hit_rate` (which is a counter) worked without problem. So I'm just gonna emit another counter for the normal hit rate instead of relying on the statsd aggregation.