### PR TITLE
Allow underscores in header names

### DIFF
--- a/Dockerfile.opensource
+++ b/Dockerfile.opensource
@@ -41,7 +41,7 @@ RUN apt-get clean
 RUN luarocks install lyaml 6.1.1-4
 RUN luarocks install luasocket 3.0rc1-2
 RUN luarocks install luafilesystem 1.6.3-2
-RUN luarocks install lua-resty-http 0.10-0
+RUN luarocks install lua-resty-http 0.12-0
 RUN luarocks install crc32 1.0
 RUN luarocks install busted 2.0.rc12-1
 RUN luarocks install cluacov

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -33,6 +33,9 @@ http {
     lua_socket_keepalive_timeout 10m;
     # Increase the default max body size (PERF-2492)
     client_max_body_size 2m;
+    # Allow underscores in headers
+    underscores_in_headers on;
+    lua_transform_underscores_in_response_headers off;
 
     # We can't create ngx.timers during init_by_lua, so we need to
     # do that while initializing workers

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -202,6 +202,19 @@ class TestGetMethod(object):
         response = get_through_spectre('/biz?foo=bar&business_id=1234')
         assert response.headers['Spectre-Cache-Status'] == 'miss'
 
+    def test_dont_drop_underscored_headers(self):
+        response = get_through_spectre(
+            '/business?foo=bar&business_id=1234',
+            extra_headers={
+                'Test-Header': 'val1',
+                'Header_with_underscores': 'val2',
+            },
+        )
+
+        headers = response.json()['received_headers']
+        assert 'test-header' in headers
+        assert 'header_with_underscores' in headers
+
 
 class TestPostMethod(object):
 


### PR DESCRIPTION
There's a bit more description in #27 but in short we need to set both `underscores_in_headers on` and `lua_transform_underscores_in_response_headers off` to allow headers to contain underscores.

We also need a newer version of lua-resty-http since the old one was converting `_` to `-`