### PR TITLE
Fix supporting all json encoding types

### DIFF
--- a/itest/backend/echo_server.py
+++ b/itest/backend/echo_server.py
@@ -65,7 +65,13 @@ class EchoServer(BaseHTTPRequestHandler):
             self.send_header('Content-Type', 'text')
             self.end_headers()
             return 'this is text'
-        self.send_header('Content-Type', 'application/json')
+
+        if ('test-content-type' in self.headers and
+                self.headers['test-content-type'] == 'application/json; charset=utf-8'
+        ):
+            self.send_header('Content-Type', 'application/json; charset=utf-8')
+        else:
+            self.send_header('Content-Type', 'application/json')
         self.end_headers()
         try:
             pattern = cache_name_configs['pattern']

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -259,6 +259,25 @@ class TestPostMethod(object):
         assert response.status_code == 200
         assert response.headers['Spectre-Cache-Status'] == 'hit'
 
+    # Test all cached post endpoints. Content-Type should be application/json; charset=utf-8
+    def test_post_always_cached_for_extended_json_content_type(self):
+        response = post_through_spectre(
+            '/post_always_cache/',
+            data={},
+            extra_headers={'content-type': 'application/json; charset=utf-8'}
+        )
+        assert response.status_code == 200
+        assert response.headers['Spectre-Cache-Status'] == 'miss'
+
+        # When calling again the result should be cached
+        response = post_through_spectre(
+            '/post_always_cache/',
+            data={},
+            extra_headers={'content-type': 'application/json; charset=utf-8'}
+        )
+        assert response.status_code == 200
+        assert response.headers['Spectre-Cache-Status'] == 'hit'
+
     def test_post_cache_hit_even_if_body_doesnt_match_without_vary(self):
         response = post_through_spectre(
             '/post_always_cache/',
@@ -557,6 +576,20 @@ class TestGetBulkRequest(object):
         # Test correctness of response based on bulk endpoint
         # (ids 1, 2 and 3 are placed in the cache during setup)
         headers, body = self.make_request_and_assert_hit([2])
+
+        # Correctness
+        assert len(body) == 1
+        assert self.base_body[1] == body[0]
+
+    def test_bulk_request_with_json_charset_response_body(self):
+        # Tests that individual ids are being cached on a bulk endpoint request
+        # The response type is application/json charset=utf-8
+        # Test correctness of response based on bulk endpoint
+        # (ids 1, 2 and 3 are placed in the cache during setup)
+        headers, body = self.make_request_and_assert_hit(
+            [2],
+            extra_headers={'test-content-type': 'application/json; charset=utf-8'}
+        )
 
         # Correctness
         assert len(body) == 1

--- a/lua/bulk_endpoints.lua
+++ b/lua/bulk_endpoints.lua
@@ -171,7 +171,7 @@ local function bulk_endpoint_caching_handler(request_info, cacheability_info)
         -- If the application is not application/json, throw an error
 
 
-        if not spectre_common.has_marker_headers(
+        if not spectre_common.has_content_type_headers(
             bulk_resp_headers_cacheable,
             spectre_common.SUPPORTED_ENCODING_FOR_ID_EXTRACTION
         ) then

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -500,6 +500,63 @@ describe("spectre_common", function()
             end)
         end)
 
+        describe("string starts with", function()
+            it("matches string starting with", function()
+                assert.is_true(
+                    spectre_common.string_starts_with("application/json; charset=utf-8", "application/json")
+                )
+            end)
+
+            it("matches whole string", function()
+                assert.is_true(
+                    spectre_common.string_starts_with("application/json", "application/json")
+                )
+            end)
+
+            it("doesn't match if pattern is not present", function()
+                assert.is_false(
+                    spectre_common.string_starts_with("application/xml", "application/json")
+                )
+            end)
+
+            it("doesn't match if pattern is not the start", function()
+                assert.is_false(
+                    spectre_common.string_starts_with("random and application/json; end", "application/json")
+                )
+            end)
+        end)
+
+        describe("has_content_type_headers", function()
+            it("validates json headers", function()
+                local headers = {['Content-Type']='application/json'}
+                assert.is_true(
+                    spectre_common.has_content_type_headers(
+                        headers,
+                        spectre_common.SUPPORTED_ENCODING_FOR_ID_EXTRACTION
+                    )
+                )
+
+                headers = {['Content-Type']='application/json; charset=utf-16'}
+                assert.is_true(
+                    spectre_common.has_content_type_headers(
+                        headers,
+                        spectre_common.SUPPORTED_ENCODING_FOR_ID_EXTRACTION
+                    )
+                )
+            end)
+
+            it("doesn't match other content type", function()
+                local headers = {['Content-Type']='application/xml'}
+                assert.is_false(
+                    spectre_common.has_content_type_headers(
+                        headers,
+                        spectre_common.SUPPORTED_ENCODING_FOR_ID_EXTRACTION
+                    )
+                )
+            end)
+        end)
+
+
     end)
 
     describe("get_target_uri", function()


### PR DESCRIPTION
Fix for the bug introduced in PR 33: https://github.com/Yelp/casper/pull/33/

- Added additional method (has_content_type_headers) in spectre_common to check if the body content-type is any of the json types. 
- Use string_starts_with (from string proposed recipes: http://lua-users.org/wiki/StringRecipes) to validate json types.
