### PR TITLE
Fix metrics and add a few metrics itests

### DIFF
--- a/itest/data/srv-configs/casper.internal.yaml
+++ b/itest/data/srv-configs/casper.internal.yaml
@@ -18,7 +18,7 @@ http:
 yelp_meteorite:
     etc_path: '/code/itest/data/etc'
     metrics-relay:
-        host: '127.0.0.1'
+        host: '10.5.0.7'
         port: 1234
 
 zipkin:

--- a/itest/docker-compose.yml
+++ b/itest/docker-compose.yml
@@ -7,6 +7,7 @@ services:
         image: spectre-dev-${USER}
         depends_on:
             - syslog
+            - metrics
         environment:
             - PAASTA_SERVICE=spectre
             - PAASTA_INSTANCE=itest
@@ -45,6 +46,7 @@ services:
         volumes_from:
             - spectre
             - syslog
+            - metrics
         depends_on:
             - backend
             - spectre
@@ -53,12 +55,20 @@ services:
                 ipv4_address: 10.5.0.4
 
     syslog:
-      build: ./syslog
-      volumes:
-        - /var/log/syslog
-      networks:
-        spectre_net:
-          ipv4_address: 10.5.0.6
+        build: ./syslog
+        volumes:
+            - /var/log/syslog
+        networks:
+            spectre_net:
+                ipv4_address: 10.5.0.6
+
+    metrics:
+        build: ./metrics
+        volumes:
+            - /var/log/metrics
+        networks:
+            spectre_net:
+              ipv4_address: 10.5.0.7
 
 networks:
     spectre_net:

--- a/itest/metrics/Dockerfile
+++ b/itest/metrics/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:bionic
+LABEL maintainer="Yelp Performance Team"
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    python3
+
+COPY listen.py /opt/listen.py
+
+CMD python3 /opt/listen.py

--- a/itest/metrics/listen.py
+++ b/itest/metrics/listen.py
@@ -1,0 +1,20 @@
+import socket
+
+
+def listen():
+    # Create a TCP/IP socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    # Bind the socket to the port
+    server_address = ('0.0.0.0', 1234)
+    sock.bind(server_address)
+
+    with open('/var/log/metrics/metrics.log', 'w') as fp:
+        while True:
+            data = sock.recv(4096)
+            fp.write('{}\n'.format(data.decode('utf-8')))
+            fp.flush()
+
+
+if __name__ == '__main__':
+    listen()

--- a/itest/test/spectre/metrics_test.py
+++ b/itest/test/spectre/metrics_test.py
@@ -1,0 +1,220 @@
+import json
+import time
+from collections import namedtuple
+
+import pytest
+
+from util import get_through_spectre
+
+METRICS_FILE = '/var/log/metrics/metrics.log'
+
+Metric = namedtuple('Metric', ['dimensions', 'value', 'type'])
+
+
+@pytest.fixture
+def log_file():
+    with open(METRICS_FILE, 'r') as fp:
+        # Ignore all the lines logged before the start of the test
+        fp.readlines()
+        yield fp
+
+
+def _parse_dimensions(dims_str):
+    # meteorite dimensions are encoded as a list of list
+    # let's convert them back to a map so they're easier to check
+    dims_map = {}
+    dims_list = json.loads(dims_str)
+    for el in dims_list:
+        dims_map[el[0]] = el[1]
+
+    return dims_map
+
+
+def _load_metrics(log_file):
+    metrics = []
+    # Metrics are emitted after the response is sent back to the client, so we need
+    # to wait a little bit before checking the file.
+    time.sleep(0.2)
+    lines = log_file.readlines()
+
+    for line in lines:
+        # statsd line format: <metric>:<value>|<type>
+        dimensions, rest = line.strip().split(':')
+        value, metric_type = rest.split('|')
+        metrics.append(Metric(_parse_dimensions(dimensions), value, metric_type))
+
+    return metrics
+
+
+def _assert_request_timing_metrics(metrics, cache_name):
+    assert len(metrics) == 4
+    assert metrics[0].dimensions == {
+        'status': '200',
+        'metric_name': 'spectre.request_timing',
+        'habitat': 'uswest1a',
+        'service_name': 'spectre',
+        'namespace': 'backend.main',
+        'instance_name': 'itest',
+        'cache_name': cache_name,
+    }
+    assert metrics[1].dimensions == {
+        'status': '200',
+        'metric_name': 'spectre.request_timing',
+        'habitat': 'uswest1a',
+        'service_name': 'spectre',
+        'namespace': '__ALL__',
+        'instance_name': 'itest',
+        'cache_name': cache_name,
+    }
+    assert metrics[2].dimensions == {
+        'status': '200',
+        'metric_name': 'spectre.request_timing',
+        'habitat': 'uswest1a',
+        'service_name': 'spectre',
+        'namespace': 'backend.main',
+        'instance_name': 'itest',
+        'cache_name': '__ALL__',
+    }
+    assert metrics[3].dimensions == {
+        'status': '200',
+        'metric_name': 'spectre.request_timing',
+        'habitat': 'uswest1a',
+        'service_name': 'spectre',
+        'namespace': '__ALL__',
+        'instance_name': 'itest',
+        'cache_name': '__ALL__',
+    }
+
+
+def _assert_fetch_hit_rate(metrics, cache_name):
+    assert len(metrics) == 2
+    assert metrics[0].dimensions == {
+        'metric_name': 'spectre.fetch_body_and_headers',
+        'habitat': 'uswest1a',
+        'service_name': 'spectre',
+        'namespace': 'backend.main',
+        'instance_name': 'itest',
+        'cache_name': cache_name,
+        'cache_status': 'miss',
+    }
+
+    assert metrics[1].dimensions == {
+        'metric_name': 'spectre.hit_rate',
+        'habitat': 'uswest1a',
+        'service_name': 'spectre',
+        'namespace': 'backend.main',
+        'instance_name': 'itest',
+        'cache_name': cache_name,
+        'cache_status': 'miss'
+    }
+
+
+def _assert_store_metric(metric, cache_name):
+    assert metric.dimensions == {
+        'metric_name': 'spectre.store_body_and_headers',
+        'habitat': 'uswest1a',
+        'service_name': 'spectre',
+        'namespace': 'backend.main',
+        'instance_name': 'itest',
+        'cache_name': cache_name,
+    }
+
+
+def test_cache_miss(log_file):
+
+    response = get_through_spectre(
+        '/timestamp/',
+    )
+    assert response.status_code == 200
+    assert response.headers['Spectre-Cache-Status'] == 'miss'
+
+    metrics = _load_metrics(log_file)
+
+    # First 2 metrics are `spectre.fetch_body_and_headers` and `spectre.hit_rate`
+    _assert_fetch_hit_rate(metrics[0:2], 'timestamp')
+
+    # Then since it's a miss we have a `spectre.store_body_and_headers`
+    _assert_store_metric(metrics[2], 'timestamp')
+
+    # Finally the `spectre.request_timing`
+    _assert_request_timing_metrics(metrics[3:7], 'timestamp')
+
+    # This assert is mostly there to make sure there are no more metrics than what I expect.
+    # The reason why it's not before the other asserts is because the error message doesn't
+    # show you what metrics are actually in the list, so it's very annoying to figure out
+    # what's missing. You'd need to comment out this check and then verify which of the
+    # other asserts is failing.
+    assert len(metrics) == 7
+
+
+def test_bulk_endpoint_miss(log_file):
+    response = get_through_spectre(
+        '/bulk_requester_2/10,11/v1?foo=bar',
+    )
+    assert response.status_code == 200
+    assert response.headers['Spectre-Cache-Status'] == 'miss'
+
+    metrics = _load_metrics(log_file)
+
+    # We have `spectre.fetch_body_and_headers` and `spectre.hit_rate` twice
+    # since we have 2 ids in the url.
+    _assert_fetch_hit_rate(metrics[0:2], 'bulk_requester_default')
+    _assert_fetch_hit_rate(metrics[2:4], 'bulk_requester_default')
+
+    # Then we have 2 `spectre.store_body_and_headers`
+    _assert_store_metric(metrics[4], 'bulk_requester_default')
+    _assert_store_metric(metrics[5], 'bulk_requester_default')
+
+    # Then the `spectre.request_timing`
+    _assert_request_timing_metrics(metrics[6:10], 'bulk_requester_default')
+
+    # Finally we have `spectre.bulk_hit_rate`
+    assert metrics[10].dimensions == {
+        'metric_name': 'spectre.bulk_hit_rate',
+        'habitat': 'uswest1a',
+        'service_name': 'spectre',
+        'namespace': 'backend.main',
+        'instance_name': 'itest',
+        'cache_name': 'bulk_requester_default',
+        'cache_status': 'miss',
+    }
+
+    # This assert is mostly there to make sure there are no more metrics than what I expect.
+    # The reason why it's not before the other asserts is because the error message doesn't
+    # show you what metrics are actually in the list, so it's very annoying to figure out
+    # what's missing. You'd need to comment out this check and then verify which of the
+    # other asserts is failing.
+    assert len(metrics) == 11
+
+
+def test_no_cache_header_metrics(log_file):
+    response = get_through_spectre(
+        '/timestamp/',
+        extra_headers={'Pragma': 'spectre-no-cache'},
+    )
+    assert response.status_code == 200
+
+    metrics = _load_metrics(log_file)
+
+    # Since we send the no-cache header we don't have a `spectre.fetch_body_and_headers`
+    # or `spectre.hit_rate`. We still update the cache though, so we have the
+    # `spectre.store_body_and_headers`
+    _assert_store_metric(metrics[0], 'timestamp')
+
+    # Finally we emit the `spectre.no_cache_header`
+    assert metrics[1].dimensions == {
+        'metric_name': 'spectre.no_cache_header',
+        'habitat': 'uswest1a',
+        'service_name': 'spectre',
+        'namespace': 'backend.main',
+        'instance_name': 'itest',
+        'reason': 'no-cache-header',
+        'cache_name': 'timestamp',
+    }
+
+    # This assert is mostly there to make sure there are no more metrics than what I expect.
+    # The reason why it's not before the other asserts is because the error message doesn't
+    # show you what metrics are actually in the list, so it's very annoying to figure out
+    # what's missing. You'd need to comment out this check and then verify which of the
+    # other asserts is failing.
+    assert len(metrics) == 2

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -641,18 +641,17 @@ class TestGetBulkRequest(object):
         assert_is_in_spectre_cache("{}?ids={}&data=false".format(base_path, '6'))
 
     def test_with_invalid_id_when_cache_missing_ids_is_true(self):
-        base_path = '/bulk_requester_2'
+        path = '/bulk_requester_2/{ids}/v1?k1=v1'
 
         # 0 < ids < 1000 are valid
-        resp1 = get_through_spectre("{}/{}/v1?k1=v2".format(base_path, '10,5000,11'))
-        headers1, body1 = resp1.headers, resp1.json()
-        assert len(body1) == 2
-        assert headers1['Spectre-Cache-Status'] == 'miss'
+        response = get_through_spectre(path.format(ids='10,5000,11'))
+        assert len(response.json()) == 2
+        assert response.headers['Spectre-Cache-Status'] == 'miss'
 
         # "5000" is an invalid id; but by default cache_missing_ids is set to true, so the
         # empty response would've been cached from the above request
-        resp2 = assert_is_in_spectre_cache("{}/{}/v1?k1=v2".format(base_path, '5000'))
-        resp2.json() == []
+        hit_response = assert_is_in_spectre_cache(path.format(ids='5000'))
+        assert hit_response.json() == []
 
     def test_with_invalid_id_when_cache_missing_ids_is_false(self):
         # 0 < ids < 1000 are valid

--- a/itest/test/spectre/zipkin_test.py
+++ b/itest/test/spectre/zipkin_test.py
@@ -1,5 +1,4 @@
 import codecs
-import re
 import os
 
 import pytest

--- a/itest/test/util.py
+++ b/itest/test/util.py
@@ -18,10 +18,13 @@ HAPROXY_ADDED_HEADERS = {
 
 NUM_ATTEMPTS_WHEN_GETTING_FROM_CACHE = 2
 
+
 def get_spectre_swagger_client():
     return SwaggerClient.from_url(SPECTRE_BASE_URL + '/swagger.json')
 
+
 spectre_swagger_client = get_spectre_swagger_client()
+
 
 def get_through_spectre(path, extra_headers=None):
     """This simulates a client GETting a resource from a service proxied
@@ -66,6 +69,7 @@ def head_through_spectre(path, extra_headers=None):
         headers.update(extra_headers)
     return requests.head(SPECTRE_BASE_URL + path, headers=headers)
 
+
 def post_through_spectre(path, data=None, extra_headers=None):
     """This simulates a client POSTing to a service proxied
     through Spectre.
@@ -75,19 +79,23 @@ def post_through_spectre(path, data=None, extra_headers=None):
         headers.update(extra_headers)
     return requests.post(SPECTRE_BASE_URL + path, data=data, headers=headers)
 
+
 def purge_resource(args):
     return spectre_swagger_client.purge.purge(**args).result()
+
 
 def get_from_spectre(path):
     """Simulates a client directly talking to spectre. No Smartstack headers
     added here."""
     return requests.get(SPECTRE_BASE_URL + path)
 
+
 def get_timestamp(path, extra_headers=None):
     """Convenience function to make a request through spectre and return only
     the 'timestamp' key of the returned json.
     """
     return get_through_spectre(path, extra_headers).json()['timestamp']
+
 
 def get_timestamp_until_hit(path, extra_headers=None):
     """Makes repeated request to the same URL and retries until

--- a/lua/metrics_helper.lua
+++ b/lua/metrics_helper.lua
@@ -92,7 +92,7 @@ end
 
 -- Emit metrics after response is sent, for external requests
 local function emit_cache_metrics(start_time, end_time, namespace, response, status)
-    if response.cacheability_info.cache_entry.is_cacheable then
+    if response.cacheability_info.is_cacheable then
         emit_request_timing(
             (end_time - start_time) * 1000,
             namespace,


### PR DESCRIPTION
Our refactorings keep messing up our metrics. This PR fixes them and adds a few itests to make sure we don't break them again in the future.

The itest coverage is poor (i.e. I don't test what happens in case of cache hits) but I don't have time right now to write more test cases. We can do that as a follow up PR.