### PR TITLE
Log full tracebacks when critical errors happen

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -13,9 +13,8 @@ http {
     # Set lua search path
     lua_package_path '/code/lua/?.lua;;';
 
-    # Also log to stderr, so we can see stacktraces in paasta logs
+    # Log to stderr, so we can see stacktraces in PaaSTA logs
     error_log /dev/stderr error;
-    error_log /dev/stdout warn;
 
     log_format main_spectre '{"time_iso8601": "$time_iso8601", "remote_addr": "$remote_addr", "connection": "$connection", "connection_requests": "$connection_requests", "http_user_agent": "$http_user_agent", "status": "$status", "request_length": "$request_length", "bytes_sent": "$bytes_sent", "request_time": "$request_time", "request_uri": "$request_uri", "unix_time": "$msec", "x_smartstack_source": "$http_x_smartstack_source", "x_smartstack_destination": "$http_x_smartstack_destination", "spectre_cache_status": "$sent_http_spectre_cache_status"}';
     access_log /dev/stdout main_spectre;

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -1,10 +1,11 @@
-local spectre_common = require 'spectre_common'
-local zipkin = require 'zipkin'
-local itest_handlers = require 'itest_post_request_handlers'
 local caching_handlers = require 'caching_handlers'
 local internal_handlers = require 'internal_handlers'
+local itest_handlers = require 'itest_post_request_handlers'
 local metrics_helper = require 'metrics_helper'
 local socket = require 'socket'
+local spectre_common = require 'spectre_common'
+local traceback = require 'traceback'
+local zipkin = require 'zipkin'
 
 
 -- The single point from where responses are sent back for proxied requests
@@ -45,9 +46,8 @@ end
 -- Handles any errors arising from processing in any part of Spectre
 -- Logs errors and returns a 500 response.
 local function err_handler(err)
-    debug.traceback()
-
-    spectre_common.log(ngx.ERR, { err=err, critical=true })
+    local tb = debug.traceback()
+    spectre_common.log(ngx.ERR, traceback.format_critical(tb, err))
     return {
         status = ngx.HTTP_INTERNAL_SERVER_ERROR,
         body = tostring(err),

--- a/lua/traceback.lua
+++ b/lua/traceback.lua
@@ -1,0 +1,11 @@
+-- Formats traceback/error information in a table used with `ngx.log`
+local function format_critical(traceback, error_message)
+    return {
+        err=error_message .. "\n\n\t" .. traceback,
+        critical=true,
+    }
+end
+
+return {
+    format_critical=format_critical,
+}

--- a/tests/lua/traceback_test.lua
+++ b/tests/lua/traceback_test.lua
@@ -1,0 +1,21 @@
+require 'busted.runner'()
+
+local traceback = require 'traceback'
+
+describe('traceback', function()
+    it("Formats traceback and error information into a table", function()
+        local tb = "stack traceback:\n\t[C]: in function 'error'\n\t/code/lua/itest_post_request_handlers.lua:8:\n\t...in function </code/lua/entry_point.lua:1>"
+        local error_message = 'Something critical happened.'
+
+        local expected_err = [[Something critical happened.
+
+	stack traceback:
+	[C]: in function 'error'
+	/code/lua/itest_post_request_handlers.lua:8:
+	...in function </code/lua/entry_point.lua:1>]]
+
+        formatted_traceback = traceback.format_critical(tb, error_message)
+        assert.are.equal(expected_err, formatted_traceback['err'])
+        assert.are.equal(true, formatted_traceback['critical'])
+    end)
+end)


### PR DESCRIPTION
This commit contains:

* a fix to ensure that full tracebacks are captured when Casper crashes in the middle of the request lifecycle
* an improvement to stop logging error-level messasges to both stdout and stderr
* a re-ordering of imports in `main.lua` (they're now alphabetized)

-------

Tested this both by adding a unit test and making Casper crash on purpose to look at the resulting log line:
```
2018/07/02 21:41:33 [error] 9#9: *2 [lua] spectre_common.lua:35: log(): {"critical":true,"err":"/code/lua/internal_handlers.lua:52: attempt to index local 'status_info' (a nil value)\n\n\tstack traceback:\n\t/code/lua/main.lua:49: in function '__newindex'\n\t/code/lua/internal_handlers.lua:52: in function 'fn'\n\t/code/lua/internal_handlers.lua:159: in function </code/lua/internal_handlers.lua:145>\n\t[C]: in function 'xpcall'\n\t/code/lua/main.lua:72: in function 'request_handler_wrapper'\n\t/code/lua/main.lua:121: in function 'main'\n\t/code/lua/entry_point.lua:3: in function </code/lua/entry_point.lua:1>"}, client: 169.254.1.1, server: , request: "GET /status HTTP/1.1", host: "localhost:32927"
```