### PR TITLE
Make Cassandra healthcheck optional.

### DIFF
--- a/itest/test/spectre/conftest.py
+++ b/itest/test/spectre/conftest.py
@@ -1,0 +1,22 @@
+import time
+
+import pytest
+
+from util import get_from_spectre
+
+
+@pytest.fixture(scope='session', autouse=True)
+def wait_for_casper():
+    """ Wait for casper and cassandra to be ready.
+
+    It takes a bit for casper and cassandra to be ready to serve requests,
+    while the tests usually start immediately without waiting.
+    """
+    for i in range(60):
+        response = get_from_spectre('/status?check_cassandra=true')
+        if response.status_code == 200:
+            return
+        else:
+            time.sleep(1)
+    else:
+        raise RuntimeError("Spectre was not ready after 60 seconds")


### PR DESCRIPTION
Having the healthcheck query cassandra was proven to be a bad idea. If
cassandra is overloaded, that'd cause the healthcheck to fail. That in
turns causes the client HAProxy to run out of healthy backends to route
requests to and return 503 errors.

It's still useful to be able to healthcheck cassandra for itests, since
we don't want to start running tests until Cassandra is ready. So I made
checking cassandra optional. We only check it if `check_cassandra=true`
is set in the HTTP request.