### PR TITLE
Add disable_caching flag to disable caching

### DIFF
--- a/lua/datastores.lua
+++ b/lua/datastores.lua
@@ -44,7 +44,7 @@ end
 -- Discovers cassandra cluster hosts for Spectre's Cassandra cluster
 -- Ananlogous in function to yelp_cassandra.connection.get_cassandra_cluster_hosts
 function cassandra_helper.get_cluster_hosts()
-    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['cassandra']
+    local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
     local contents = io.open(configs['seeds_file']):read()
     local hosts = {}
 
@@ -90,7 +90,7 @@ function cassandra_helper.init()
 end
 
 function cassandra_helper.create_cluster(cluster_module, shm, timeout)
-    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['cassandra']
+    local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
     local hosts = cassandra_helper.get_cluster_hosts()
     spectre_common.log(ngx.WARN, { err='init ' .. shm .. ' cluster with timeout ' .. timeout, critical=false })
     -- Use datacenter-aware load balancing policy
@@ -122,7 +122,7 @@ end
 
 -- Creates the Cassandra cluster tables to serve as the clients for subsequent queries
 function cassandra_helper.init_with_cluster(cluster_module)
-    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['cassandra']
+    local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
     ngx.shared.cassandra_read_cluster = cassandra_helper.create_cluster(
         cluster_module,
         'cassandra_read_conn',
@@ -174,7 +174,7 @@ end
 -- Checks to see if Cassandra is available and the required keyspace and table are present
 -- used with the /status endpoint
 function cassandra_helper.healthcheck(cluster)
-    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['cassandra']
+    local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
     local db_check = cassandra_helper.execute(
         cluster,
         'select * from system.schema_keyspaces where keyspace_name = ?',
@@ -198,7 +198,7 @@ function cassandra_helper.get_bucket(key, id, cache_name, namespace, num_buckets
         0,
         table.concat({unique_id, cache_name, namespace}, '::')
     )
-    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['cassandra']
+    local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
     local max_buckets = num_buckets or configs['default_num_buckets']
     return hash % max_buckets
 end
@@ -207,7 +207,7 @@ end
 function cassandra_helper.store_body_and_headers(cluster, ids, cache_key, namespace, cache_name,
                                                  body, headers, vary_headers, ttl, num_buckets)
 
-    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['cassandra']
+    local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
     local bucket = cassandra_helper.get_bucket(cache_key, ids[1], cache_name, namespace, num_buckets)
     local consistency = cassandra.consistencies[configs['write_consistency']]
     local stmt = 'INSERT INTO cache_store (bucket, namespace, cache_name, id, key, vary_headers, body, headers)\
@@ -297,7 +297,7 @@ function cassandra_helper.purge(cluster, namespace, cache_name, id)
     local delete_statement = 'DELETE FROM cache_store WHERE bucket = ? AND cache_name = ? AND namespace = ?'
     local statement_args = {nil, cache_name, namespace}
 
-    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['cassandra']
+    local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
     local bucket_min = 0
     local bucket_max = configs['default_num_buckets']-1
 

--- a/lua/http.lua
+++ b/lua/http.lua
@@ -3,7 +3,7 @@ local http = require "resty.http"
 
 
 local function make_http_request(method, uri, headers)
-    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['http']
+    local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['http']
     local httpc = http.new()
     httpc:set_timeout(configs['timeout_ms'])
 

--- a/lua/metrics_helper.lua
+++ b/lua/metrics_helper.lua
@@ -7,7 +7,9 @@ local _default_dimensions
 
 local function _get_sock()
     if _sock == nil then
-        local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['yelp_meteorite']
+        local configs = config_loader.get_spectre_config_for_namespace(
+            config_loader.CASPER_INTERNAL_NAMESPACE
+        )['yelp_meteorite']
         _sock = socket.udp()
         _sock:setsockname("*", 0)
         _sock:setpeername(
@@ -19,7 +21,9 @@ local function _get_sock()
 end
 
 local function get_system_dimension(name)
-    local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['yelp_meteorite']
+    local configs = config_loader.get_spectre_config_for_namespace(
+        config_loader.CASPER_INTERNAL_NAMESPACE
+    )['yelp_meteorite']
     return io.open(configs['etc_path'] .. '/' .. name):read()
 end
 

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -129,7 +129,9 @@ local function determine_if_cacheable(url, namespace, request_headers)
         refresh_cache = false,
     }
 
-    local spectre_config = config_loader.get_spectre_config_for_namespace('casper.internal')
+    local spectre_config = config_loader.get_spectre_config_for_namespace(
+        config_loader.CASPER_INTERNAL_NAMESPACE
+    )
     if tostring(spectre_config['disable_caching']) == 'true' then
         cacheability_info.reason = 'caching disabled via configs'
         return cacheability_info

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -129,14 +129,20 @@ local function determine_if_cacheable(url, namespace, request_headers)
         refresh_cache = false,
     }
 
-    local spectre_config = config_loader.get_spectre_config_for_namespace(namespace)
-    if spectre_config == nil then
+    local spectre_config = config_loader.get_spectre_config_for_namespace('casper.internal')
+    if tostring(spectre_config['disable_caching']) == 'true' then
+        cacheability_info.reason = 'caching disabled via configs'
+        return cacheability_info
+    end
+
+    local namespace_config = config_loader.get_spectre_config_for_namespace(namespace)
+    if namespace_config == nil then
         cacheability_info.reason = 'non-configured-namespace (' .. namespace .. ')'
         return cacheability_info
     end
 
     local http_method = ngx.req.get_method()
-    for cache_name, cache_entry in pairs(spectre_config['cached_endpoints']) do
+    for cache_name, cache_entry in pairs(namespace_config['cached_endpoints']) do
         if ngx.re.match(url, cache_entry['pattern']) and (
             -- Compute if http_method is same as in config or http method is GET
             cache_entry['request_method'] == http_method or DEFAULT_REQUEST_METHOD == http_method

--- a/lua/zipkin.lua
+++ b/lua/zipkin.lua
@@ -22,7 +22,9 @@ function zipkin._get_sock()
     if _sock == nil then
         _sock = socket.udp()
         _sock:setsockname("*", 0)
-        local configs = config_loader.get_spectre_config_for_namespace('casper.internal')['zipkin']
+        local configs = config_loader.get_spectre_config_for_namespace(
+            config_loader.CASPER_INTERNAL_NAMESPACE
+        )['zipkin']
         _sock:setpeername(
             configs['syslog']['host'],
             configs['syslog']['port']

--- a/tests/lua/datastores_test.lua
+++ b/tests/lua/datastores_test.lua
@@ -31,7 +31,7 @@ describe('cassandra_helper', function()
 
         config_loader = require 'config_loader'
         config_loader.load_services_configs('/code/tests/data/srv-configs')
-        configs = config_loader.get_spectre_config_for_namespace('casper.internal')['cassandra']
+        configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
 
         stub(ngx, 'log')
     end)

--- a/tests/lua/metrics_helper_test.lua
+++ b/tests/lua/metrics_helper_test.lua
@@ -6,7 +6,7 @@ describe("metrics_helper", function()
     setup(function()
         config_loader = require 'config_loader'
         config_loader.load_services_configs('/code/tests/data/srv-configs')
-        configs = config_loader.get_spectre_config_for_namespace('casper.internal')['yelp_meteorite']
+        configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['yelp_meteorite']
 
         stub(ngx, 'log')
     end)

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -40,7 +40,7 @@ describe("spectre_common", function()
                 }
             })
             ngx.req.get_method = function() return 'GET' end
-            local spectre_configs = config_loader.get_spectre_config_for_namespace('casper.internal')
+            local spectre_configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)
 
             spectre_configs['disable_caching'] = true
             local cacheability_info = spectre_common.determine_if_cacheable('/cached', 'srv.main', {})


### PR DESCRIPTION
This PR adds a new `disable_caching` flag that can be used to disable caching for all namespaces and caches. This is sometimes useful to easily turn off caching in a specific region.