### PR TITLE
Drop accept: application/msgpack header if the request is cached.

### DIFF
--- a/itest/data/srv-configs/backend.main.yaml
+++ b/itest/data/srv-configs/backend.main.yaml
@@ -29,6 +29,7 @@ cached_endpoints:
         id_identifier: 'bulk_id'
         pattern: "(^/bulk_requester(?:\\?|\\?.*&)ids=)((?:\\S|%2C)+)(.*$)"
         ttl: 30
+        vary_headers: ['accept', 'accept-encoding']
     bulk_requester_default:
         bulk_support: true
         id_identifier: 'bulk_id'

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -747,11 +747,10 @@ class TestGetBulkRequest(object):
         assert body1 == body2
         assert body2 == body3
 
-    def test_msgpack_is_disabled(self):
+    def test_msgpack_is_allowed_for_normal_endpoints(self):
         resp = get_through_spectre('/timestamp/get', extra_headers={'Accept': 'application/msgpack'})
         assert resp.headers['Spectre-Cache-Status'] == 'miss'
-        assert 'Accept' not in resp.json()['received_headers']
-        assert 'accept' not in resp.json()['received_headers']
+        assert resp.json()['received_headers']['accept'] == 'application/msgpack'
 
     def test_non_application_json(self):
         extra_header = {'test-content-type': 'text'}

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -747,6 +747,12 @@ class TestGetBulkRequest(object):
         assert body1 == body2
         assert body2 == body3
 
+    def test_msgpack_is_disabled(self):
+        resp = get_through_spectre('/timestamp/get', extra_headers={'Accept': 'application/msgpack'})
+        assert resp.headers['Spectre-Cache-Status'] == 'miss'
+        assert 'Accept' not in resp.json()['received_headers']
+        assert 'accept' not in resp.json()['received_headers']
+
     def test_non_application_json(self):
         extra_header = {'test-content-type': 'text'}
         base_path = '/bulk_requester'

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -171,6 +171,12 @@ function caching_handlers._parse_request(incoming_zipkin_headers)
         ngx.req.clear_header("accept-encoding")
         request_headers['accept-encoding'] = nil
     end
+    -- Let's also remove the 'application/msgpack' Accept header so that it's easier to
+    -- parse the response.
+    if ngx.re.match(ngx.req.get_headers()['accept'], 'application/msgpack') then
+        ngx.req.clear_header("accept")
+        request_headers['accept'] = nil
+    end
 
     if cacheability_info.is_cacheable or cacheability_info.refresh_cache then
         local vary_headers = spectre_common.get_vary_headers(request_headers, cacheability_info.vary_headers_list)

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -166,16 +166,18 @@ function caching_handlers._parse_request(incoming_zipkin_headers)
     local destination = spectre_common.get_smartstack_destination(request_headers)
     local cacheability_info = spectre_common.determine_if_cacheable(normalized_uri, destination, request_headers)
 
-    -- Remove the gzip header because it's easier to work with text responses
-    if ngx.re.match(ngx.req.get_headers()['accept-encoding'], 'gzip') then
-        ngx.req.clear_header("accept-encoding")
-        request_headers['accept-encoding'] = nil
-    end
-    -- Let's also remove the 'application/msgpack' Accept header so that it's easier to
-    -- parse the response.
-    if ngx.re.match(ngx.req.get_headers()['accept'], 'application/msgpack') then
-        ngx.req.clear_header("accept")
-        request_headers['accept'] = nil
+    -- Modify request headers if it's a bulk endpoint since we need the response to
+    -- be pure uncompressed JSON
+    if cacheability_info.is_cacheable and cacheability_info.cache_entry.bulk_support then
+        -- Remove the gzip header because it's easier to work with text responses
+        if ngx.re.match(ngx.req.get_headers()['accept-encoding'], 'gzip') then
+            ngx.req.clear_header("accept-encoding")
+            request_headers['accept-encoding'] = nil
+        end
+        -- Let's also set the 'application/json' Accept header since we can only
+        -- handle pure json responses.
+        ngx.req.set_header('accept', 'application/json')
+        request_headers['accept'] = 'application/json'
     end
 
     if cacheability_info.is_cacheable or cacheability_info.refresh_cache then


### PR DESCRIPTION
The itest fails without the changes to `lua/caching_handlers.lua` and
passes afterwards.