### PR TITLE
Use kaisen's lua-cassandra to debug how often responses are hanging

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -14,7 +14,7 @@ http {
     lua_package_path '/code/lua/?.lua;;';
 
     # Log to stderr, so we can see stacktraces in PaaSTA logs
-    error_log /dev/stderr error;
+    error_log /dev/stderr warn;
 
     log_format main_spectre '{"time_iso8601": "$time_iso8601", "remote_addr": "$remote_addr", "connection": "$connection", "connection_requests": "$connection_requests", "http_user_agent": "$http_user_agent", "status": "$status", "request_length": "$request_length", "bytes_sent": "$bytes_sent", "request_time": "$request_time", "request_uri": "$request_uri", "unix_time": "$msec", "x_smartstack_source": "$http_x_smartstack_source", "x_smartstack_destination": "$http_x_smartstack_destination", "spectre_cache_status": "$sent_http_spectre_cache_status"}';
     access_log /dev/stdout main_spectre;

--- a/lua-cassandra-dev-0.rockspec
+++ b/lua-cassandra-dev-0.rockspec
@@ -3,7 +3,7 @@ version = "dev-0"
 -- lua-cassandra fork with stream_id support
 -- https://github.com/thibaultcha/lua-cassandra/pull/104
 source = {
-  url = "git://github.com/drolando/lua-cassandra",
+  url = "git://github.com/kaisen/lua-cassandra",
   branch = "add_stream_id_support_dev"
 }
 description = {


### PR DESCRIPTION
This branch/commit (https://github.com/kaisen/lua-cassandra/commit/470a5304ba54ae2be41da971acb518d494b4df37) contains logging that records how long responses are hanging when sending. This will help debug timing spikes.