### PR TITLE
Periodically refresh cassandra clusters topology

### DIFF
--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -53,6 +53,9 @@ function caching_handlers._post_request_callback(response, request_info, cacheab
     local cache_uri = caching_handlers._get_cache_uri(request_info)
     local success, err = xpcall(
         function()
+            -- Refresh cluster topology before writing the result
+            cassandra_helper.refresh()
+
             spectre_common.cache_store(
                 cassandra_helper,
                 ids,

--- a/lua/datastores.lua
+++ b/lua/datastores.lua
@@ -285,6 +285,8 @@ function cassandra_helper.fetch_body_and_headers(
     }
 end
 
+-- Refreshes the cassandra cluster topology. lua-cassandra doesn't do that automatically
+-- so we have to do this periodically to detect changes in the cluster.
 function cassandra_helper.refresh()
     local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
     local now = ngx.now()

--- a/tests/data/srv-configs/casper.internal.yaml
+++ b/tests/data/srv-configs/casper.internal.yaml
@@ -1,5 +1,4 @@
 cassandra:
-    seeds_file: '/code/tests/data/synapse/services/cassandra_casper.main.json'
     connect_timeout_ms: 100
     default_num_buckets: 1000
     keyspace: 'spectre_db'
@@ -7,7 +6,9 @@ cassandra:
     local_region: '.*'
     num_retries: 3
     read_timeout_ms: 15
+    refresh_interval: 60
     retry_on_timeout: false
+    seeds_file: '/code/tests/data/synapse/services/cassandra_casper.main.json'
     write_consistency: 'all'
     write_timeout_ms: 1000
 

--- a/tests/lua/caching_handlers_test.lua
+++ b/tests/lua/caching_handlers_test.lua
@@ -10,6 +10,8 @@ insulate('caching_handlers', function()
     local old_get_id_from_req_body
     local old_extract_ids_from_uri
     local spectre_common
+    local cassandra_helper
+    local cassandra_helper_mock
 
     setup(function()
         _G.package.loaded.socket = {
@@ -26,6 +28,10 @@ insulate('caching_handlers', function()
                 }
             end
         }
+
+        local datastores = require 'datastores'
+        cassandra_helper = datastores.cassandra_helper
+        cassandra_helper_mock = mock(cassandra_helper, true)
 
         bulk_endpoints = require 'bulk_endpoints'
         caching_handlers = require 'caching_handlers'
@@ -88,6 +94,7 @@ insulate('caching_handlers', function()
                 }
             )
 
+            assert.stub(cassandra_helper_mock.refresh).was_called()
             assert.stub(spectre_common.cache_store).was_called()
             assert.stub(spectre_common.cache_store).was_called_with(
                 match.is_table(),
@@ -133,6 +140,7 @@ insulate('caching_handlers', function()
                 }
             )
 
+            assert.stub(cassandra_helper_mock.refresh).was_called()
             assert.stub(spectre_common.cache_store).was_called()
             assert.stub(spectre_common.cache_store).was_called_with(
                 match.is_table(),


### PR DESCRIPTION
Fixes #46 

lua-cassandra doesn't automatically detect changes in the ring topology. You have to manually call cluster:refresh() for it to pick up any change. This is a problem when we're replacing nodes in the C* cluster since the driver will keep trying to connect to the old ones and ignore any new host.

With this change we call refresh() even N seconds, always after the response has been returned.