### PR TITLE
Inject X-Smartstack-Source header in Casper

### DIFF
--- a/itest/data/srv-configs/casper.internal.yaml
+++ b/itest/data/srv-configs/casper.internal.yaml
@@ -1,3 +1,6 @@
+casper:
+    x_smartstack_source_value: 'spectre.main'
+
 cassandra:
     seeds_file: '/code/itest/data/synapse/services/cassandra_casper.main.json'
     connect_timeout_ms: 500

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -2,6 +2,7 @@
 import time
 
 import bravado.exception
+import json
 import pytest
 import requests
 import socket
@@ -214,6 +215,11 @@ class TestGetMethod(object):
         headers = response.json()['received_headers']
         assert 'test-header' in headers
         assert 'header_with_underscores' in headers
+
+    def test_x_smartstack_source_is_inserted(self):
+        response = get_through_spectre('/biz?foo=bar&business_id=1234')
+        content = json.loads(response.content)
+        assert content["received_headers"]["x-smartstack-source"] == "spectre.main"
 
 
 class TestPostMethod(object):

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -219,7 +219,7 @@ class TestGetMethod(object):
     def test_x_smartstack_source_is_inserted(self):
         response = get_through_spectre('/biz?foo=bar&business_id=1234')
         content = json.loads(response.content)
-        assert content["received_headers"]["x-smartstack-source"] == "spectre.main"
+        assert content['received_headers']['x-smartstack-source'] == 'spectre.main'
 
 
 class TestPostMethod(object):

--- a/itest/test/util.py
+++ b/itest/test/util.py
@@ -13,7 +13,6 @@ BACKEND_NAMESPACE = 'backend.main'
 
 HAPROXY_ADDED_HEADERS = {
     'X-Smartstack-Destination': BACKEND_NAMESPACE,
-    'X-Smartstack-Source': 'some.source.main',
 }
 
 NUM_ATTEMPTS_WHEN_GETTING_FROM_CACHE = 2

--- a/lua/main.lua
+++ b/lua/main.lua
@@ -107,6 +107,8 @@ local function main()
         ngx.req.get_headers()
     )
 
+    spectre_common.inject_source_header(ngx.req)
+
     if should_proxy then
         request_handler_wrapper(caching_handlers.caching_proxy, false)
     elseif err then

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -314,8 +314,12 @@ local function forward_to_destination(method, request_uri, request_headers)
     }
 end
 
+-- Injects the `X-Smartstack-Source` header so HAProxy/Envoy knows this
+-- request was already proxied through Casper.
 local function inject_source_header(request)
-   request.set_header('X-Smartstack-Source', 'spectre.main')
+    local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)
+    local x_smartstack_source_value = configs['casper']['x_smartstack_source_value']
+    request.set_header('X-Smartstack-Source', x_smartstack_source_value)
 end
 
 -- Validates a header. Returns nil if everything looks good, otherwise

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -318,7 +318,13 @@ end
 -- request was already proxied through Casper.
 local function inject_source_header(request)
     local configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)
-    local x_smartstack_source_value = configs['casper']['x_smartstack_source_value']
+    local x_smartstack_source_value = "spectre.main"
+
+    -- attempt to retrieve value from config, otherwise keep default
+    if configs['casper'] ~= nil and configs['casper']['x_smartstack_source_value'] ~= nil then
+        x_smartstack_source_value = configs['casper']['x_smartstack_source_value']
+    end
+
     request.set_header('X-Smartstack-Source', x_smartstack_source_value)
 end
 

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -335,9 +335,9 @@ end
 -- proxied service (returns true) or for Spectre itself (returns an error message).
 -- Returns an error message as a string if a malformed request is detected.
 -- --
--- To be proxied through spectre, a request needs 2 headers
+-- To be proxied through Casper, a request needs the following headers:
 -- + X-SmartStack-Destination: the nerve namespace of the service called. This
---   lets Spectre lookup the relevant set of configs and forward to the right
+--   lets Casper lookup the relevant set of configs and forward to the right
 --   service.
 -- --
 -- Both of these headers are inserted by HAProxy for services configured with

--- a/lua/zipkin.lua
+++ b/lua/zipkin.lua
@@ -65,18 +65,6 @@ function zipkin.get_new_headers(incoming_zipkin_headers)
 end
 
 
--- Modify relevant Zipkin headers for downstream request.
-function zipkin.inject_zipkin_headers(incoming_zipkin_headers)
-    local new_zipkin_headers = zipkin.get_new_headers(incoming_zipkin_headers)
-    local headers = {}
-    for header_name, header_val in pairs(new_zipkin_headers) do
-        ngx.req.set_header(header_name, header_val)
-        headers[header_name] = header_val
-    end
-
-    return headers
-end
-
 -- If Zipkin headers exist, then log them to syslog. X-B3-Flags and X-B3-Sampled
 -- are optional in the Zipkin spec, so we'll emit a '-' if they're not present.
 -- Start and end times are in epoch seconds, but Zipkin wants them in microseconds.

--- a/tests/data/srv-configs/casper.internal.yaml
+++ b/tests/data/srv-configs/casper.internal.yaml
@@ -1,5 +1,5 @@
 casper:
-    x_smartstack_source_value: 'spectre.main'
+    x_smartstack_source_value: 'spectre.notthedefaultvalue'
 
 cassandra:
     seeds_file: '/code/tests/data/synapse/services/cassandra_casper.main.json'

--- a/tests/data/srv-configs/casper.internal.yaml
+++ b/tests/data/srv-configs/casper.internal.yaml
@@ -1,3 +1,6 @@
+casper:
+    x_smartstack_source_value: 'spectre.main'
+
 cassandra:
     seeds_file: '/code/tests/data/synapse/services/cassandra_casper.main.json'
     connect_timeout_ms: 100

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -343,7 +343,6 @@ describe("spectre_common", function()
         describe("is_request_for_proxied_service", function()
             it("Returns true and no error for proxied requests", function()
                 local should_proxy, err = spectre_common.is_request_for_proxied_service('GET', {
-                    ['X-Smartstack-Source'] = 'src',
                     ['X-Smartstack-Destination'] = 'dst',
                 })
                 assert.are.equal(true, should_proxy)
@@ -361,7 +360,6 @@ describe("spectre_common", function()
             end)
             it("Errors out when multiple destination values are provided", function()
                 local should_proxy, err = spectre_common.is_request_for_proxied_service('GET', {
-                    ['X-Smartstack-Source'] = 'src',
                     ['X-Smartstack-Destination'] = {'dst1', 'dst2'},
                 })
                 assert.are.equal(false, should_proxy)
@@ -369,11 +367,10 @@ describe("spectre_common", function()
             end)
             it("Combines error messages when multiple sources AND destinations are provided", function()
                 local should_proxy, err = spectre_common.is_request_for_proxied_service('GET', {
-                    ['X-Smartstack-Source'] = {'src1', 'src2'},
                     ['X-Smartstack-Destination'] = {'dst1', 'dst2'},
                 })
                 assert.are.equal(false, should_proxy)
-                assert.are.equal('X-Smartstack-Source has multiple values: src1 src2; X-Smartstack-Destination has multiple values: dst1 dst2;', err)
+                assert.are.equal('X-Smartstack-Destination has multiple values: dst1 dst2;', err)
             end)
         end)
 


### PR DESCRIPTION
This incorporates @bplotnick's work which I haven't touched yet. Maybe we need to not-hardcode the `spectre.main` value that is being injected? I see that HAProxy gets a hold of a `proxied_through` value to inject the same header but when we're in Casper we know it's gonna be `spectre.main`.

Test-wise, I've gotten around to figure out how Casper does tests and itests and it turns out we use a fake backend behind Casper to return whatever was sent to it, so I just make a request that doesn't have a `X-Smartstack-Source` header and check if the backend received one.