### PR TITLE
Stop writing access logs to stdout

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -16,9 +16,6 @@ http {
     # Log to stderr, so we can see stacktraces in PaaSTA logs
     error_log /dev/stderr error;
 
-    log_format main_spectre '{"time_iso8601": "$time_iso8601", "remote_addr": "$remote_addr", "connection": "$connection", "connection_requests": "$connection_requests", "http_user_agent": "$http_user_agent", "status": "$status", "request_length": "$request_length", "bytes_sent": "$bytes_sent", "request_time": "$request_time", "request_uri": "$request_uri", "unix_time": "$msec", "x_smartstack_source": "$http_x_smartstack_source", "x_smartstack_destination": "$http_x_smartstack_destination", "spectre_cache_status": "$sent_http_spectre_cache_status"}';
-    access_log /dev/stdout main_spectre;
-
     lua_shared_dict cassandra_read_conn 1m;
     lua_shared_dict cassandra_read_cluster 1m;
     lua_shared_dict cassandra_write_conn 1m;


### PR DESCRIPTION
There's a bug in docker that causes it to use a lot of CPU processing
stdout. We don't really use those logs anyway and they're already also
sent to syslog.

I'm keeping error logs on stderr since those are useful.