### PR TITLE
Adding option to disable stdout logs

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -17,6 +17,7 @@ http {
     error_log /dev/stderr error;
 
     log_format main_spectre '{"time_iso8601": "$time_iso8601", "remote_addr": "$remote_addr", "connection": "$connection", "connection_requests": "$connection_requests", "http_user_agent": "$http_user_agent", "status": "$status", "request_length": "$request_length", "bytes_sent": "$bytes_sent", "request_time": "$request_time", "request_uri": "$request_uri", "unix_time": "$msec", "x_smartstack_source": "$http_x_smartstack_source", "x_smartstack_destination": "$http_x_smartstack_destination", "spectre_cache_status": "$sent_http_spectre_cache_status"}';
+    # Update start.sh script if you change next line
     access_log /dev/stdout main_spectre;
 
     lua_shared_dict cassandra_read_conn 1m;

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -348,13 +348,11 @@ class TestPostMethod(object):
         assert response.headers['Spectre-Cache-Status'] == 'miss'
 
         # Calling again with more fields in body which are ignored would also be a cache hit
-        response = post_through_spectre(
-            '/post_id_cache_variable_body/',
-            data='{"request_id":234, "ignore_field1":"xyz", "ignore_field2":"21"}',
+        assert_is_in_spectre_cache(
+            '/post_id_cache_variable_body/', 
+            data='{"request_id":234, "ignore_field1":"xyz", "ignore_field3":"21"}',
             extra_headers={'content-type': 'application/json'}
         )
-        assert response.status_code == 200
-        assert response.headers['Spectre-Cache-Status'] == 'hit'
 
     def test_post_cached_with_id_can_be_purged(self):
         response = post_through_spectre(

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -275,7 +275,6 @@ class TestPostMethod(object):
         assert response.status_code == 200
         assert response.headers['Spectre-Cache-Status'] == 'miss'
 
-        time.sleep(0.2)
         # When calling again the result should be cached
         response = post_through_spectre(
             '/post_always_cache/',

--- a/itest/test/spectre/spectre_test.py
+++ b/itest/test/spectre/spectre_test.py
@@ -275,6 +275,7 @@ class TestPostMethod(object):
         assert response.status_code == 200
         assert response.headers['Spectre-Cache-Status'] == 'miss'
 
+        time.sleep(0.2)
         # When calling again the result should be cached
         response = post_through_spectre(
             '/post_always_cache/',

--- a/itest/test/util.py
+++ b/itest/test/util.py
@@ -46,7 +46,10 @@ def assert_is_in_spectre_cache(*args, **kwargs):
     Args/kwargs passed here are passed through to `get_through_spectre`
     """
     for _ in range(NUM_ATTEMPTS_WHEN_GETTING_FROM_CACHE):
-        response = get_through_spectre(*args, **kwargs)
+        if 'data' in kwargs:
+            response = post_through_spectre(*args, **kwargs)
+        else:
+            response = get_through_spectre(*args, **kwargs)
         if response.headers['Spectre-Cache-Status'] == 'hit':
             return response
         else:

--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,7 @@ SERVICES_YAML_PATH=${SERVICES_YAML_PATH:-/nail/etc/services/services.yaml}
 CASSANDRA_CLUSTER_CONFIG=${CASSANDRA_CLUSTER_CONFIG:-/var/run/synapse/services/cassandra_spectre.main.json}
 # We run 1 worker per container in production
 WORKER_PROCESSES=${WORKER_PROCESSES:-1}
+NGINX_CONF=/code/config/nginx.conf
 
 if [ $ACCEPTANCE ]; then
     # Cassandra ip is automatically generated
@@ -12,8 +13,20 @@ if [ $ACCEPTANCE ]; then
     echo '[{"name": "cassandra-spectre-itest","host": "'$host'","port": 9042,"id": 1,"weight": 10}]' > $CASSANDRA_CLUSTER_CONFIG
 fi
 
+if [ "$DISABLE_STDOUT_ACCESS_LOG" = "1" ]; then
+    # We already send logs to syslog from Lua.
+    # Setting this env var to 1 will disable redundant nginx access log
+    echo -n "Disabling access log on stdout: "
+    sed -i -e "s/access_log \/dev\/stdout main_spectre;/access_log off;/g;{q3}" $NGINX_CONF
+    # Let's exit if the substitution doesn't go exactly as planned
+    [[ ! $? == 0 ]] && echo "error disabling stdout access_logs" && exit 1
+    echo "done"
+else
+    echo "Set env var DISABLE_STDOUT_ACCESS_LOG to 1 to disable stdout access logging"
+fi
+
 SRV_CONFIGS_PATH=$SRV_CONFIGS_PATH \
     SERVICES_YAML_PATH=$SERVICES_YAML_PATH \
     /usr/local/openresty/nginx/sbin/nginx \
-        -c /code/config/nginx.conf \
+        -c $NGINX_CONF \
         -g "worker_processes $WORKER_PROCESSES;"


### PR DESCRIPTION
Tests:
Setting the env variable to 1
```
Healthcheck succeeded!: 'http request succeeded, code 200' 
Your service is now running! Tailing stdout and stderr:
Disabling access log on stdout: done
```
```
dev1-uswest1cdevc:~/git/casper % curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:54423/status
200%
```
No logs are written to stdout


Not setting or setting the environment variable to something else that 1
```
container [130d941bdc9c]: Set env var DISABLE_STDOUT_ACCESS_LOG to 1 to disable stdout access logging
```
logs are displayed as usual


Changing the access logging in nginx.conf
container [19a54d04852d]: Disabling access log on stdout: error disabling stdout access_logs
Container exited with code 1

