### PR TITLE
Fix bogus sed expression

### DIFF
--- a/itest/docker-compose.yml
+++ b/itest/docker-compose.yml
@@ -14,6 +14,7 @@ services:
             - SRV_CONFIGS_PATH=/code/itest/data/srv-configs
             - SERVICES_YAML_PATH=/code/itest/data/services.yaml
             - WORKER_PROCESSES=1
+            - DISABLE_STDOUT_ACCESS_LOG=1
         volumes:
             - /var/log/nginx
             - ./data/etc:/nail/etc:ro

--- a/start.sh
+++ b/start.sh
@@ -14,10 +14,14 @@ if [ $ACCEPTANCE ]; then
 fi
 
 if [ "$DISABLE_STDOUT_ACCESS_LOG" = "1" ]; then
-    # We already send logs to syslog from Lua.
-    # Setting this env var to 1 will disable redundant nginx access log
+    # We already send logs to syslog from the Lua code.
+    # To avoid duplicate logging, we can disable stdout access_logs.
     echo -n "Disabling access log on stdout: "
+    # Search for exact string to substitue
+    # If found, we run the subsitution command and jump to next line
+    # If not found, we exit 3
     sed -i -e "/access_log \/dev\/stdout main_spectre;/,\${s//access_log off;/;b};\$q3" $NGINX_CONF
+
     # Let's exit if the substitution doesn't go exactly as planned
     [[ ! $? == 0 ]] && echo "error disabling stdout access_logs" && exit 1
     echo "done"

--- a/start.sh
+++ b/start.sh
@@ -17,7 +17,7 @@ if [ "$DISABLE_STDOUT_ACCESS_LOG" = "1" ]; then
     # We already send logs to syslog from Lua.
     # Setting this env var to 1 will disable redundant nginx access log
     echo -n "Disabling access log on stdout: "
-    sed -i -e "s/access_log \/dev\/stdout main_spectre;/access_log off;/g;{q3}" $NGINX_CONF
+    sed -i -e "/access_log \/dev\/stdout main_spectre;/,\${s//access_log off;/;b};\$q3" $NGINX_CONF
     # Let's exit if the substitution doesn't go exactly as planned
     [[ ! $? == 0 ]] && echo "error disabling stdout access_logs" && exit 1
     echo "done"


### PR DESCRIPTION
There was a problem in my previous sed syntax. I was fortunately able to catch the issue with the following error log:
`Disabling access log on stdout: error disabling stdout access_logs`

This is a better way of making sure that we exit with code 3 if no substitution has been made.
```
~/git/casper/config % cp nginx.conf test && sed -i -e "/access_log \/dev\/stdout main_spectre;/,\${s//access_log off;/;b};\$q3" test ;echo $? ; diff nginx.conf test                             (git)-[master]
0
21c21
<     access_log /dev/stdout main_spectre;
---
>     access_log off;
~/git/casper/config % cp nginx.conf test && sed -i -e "/access_log \/dev\/stdout main_GHOST;/,\${s//access_log off;/;b};\$q3" test ;echo $? ; diff nginx.conf test                               (git)-[master]
3
```