### PR TITLE
Build image again in itests

### DIFF
--- a/Dockerfile.opensource
+++ b/Dockerfile.opensource
@@ -10,6 +10,7 @@ RUN apt-get -o Acquire::ForceIPv4=true update && \
         ca-certificates \
         dnsutils \
         git \
+        gpg-agent \
         libluajit-5.1-2 \
         # libyaml-dev is needed to install lyaml
         libyaml-dev \
@@ -26,9 +27,9 @@ RUN add-apt-repository -y "deb http://openresty.org/package/ubuntu $(lsb_release
 # Need to pin openresty to the 1.11.2.3 version as our tests break with newer versions.
 # I think this is due to bad test syntax on our side, so we should fix that: PERF-2785
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    openresty=1.13.6.2-1~xenial1 \
-    openresty-opm=1.13.6.2-1~xenial1 \
-    openresty-resty=1.13.6.2-1~xenial1
+    openresty \
+    openresty-opm \
+    openresty-resty
 
 # Manually install dumb-init as it's not in the public APT repo
 RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64.deb

--- a/Dockerfile.opensource
+++ b/Dockerfile.opensource
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 LABEL maintainer="Yelp Performance Team"
 
 # public apt-get mirrors are terribly slow if your network supports ipv6

--- a/itest/docker-compose.yml
+++ b/itest/docker-compose.yml
@@ -4,9 +4,7 @@ services:
     spectre:
         cap_add:
             - NET_ADMIN
-        build:
-            context: ..
-            dockerfile: Dockerfile.opensource
+        image: ${DOCKER_TAG}
         depends_on:
             - syslog
             - metrics

--- a/itest/docker-compose.yml
+++ b/itest/docker-compose.yml
@@ -4,7 +4,9 @@ services:
     spectre:
         cap_add:
             - NET_ADMIN
-        image: spectre-dev-${USER}
+        build:
+            context: ..
+            dockerfile: Dockerfile.opensource
         depends_on:
             - syslog
             - metrics


### PR DESCRIPTION
Jenkins changes the DOCKER_TAG variable, which makes cook-image create
an image with a different name.
Right now docker-compose expects the image to be called
spectre-dev-$USER, which isn't true anymore. The easiest way to fix this
is to rebuild the image during itests. All the layers should be cached
so it's gonna be very fast.

NOTE: this means that even internally in jenkins itests will always use the
opensource image and not the yelp specific one.