### PR TITLE
Run tests and casper locally and not in a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 .dockerignore
 tests/
 data/
+luarocks/
+resty_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.sw[a-z]
 bin/docker-compose*
+logs/
+luacov.report.out
+luacov.stats.out
+luarocks/
+resty_modules/

--- a/.luacov
+++ b/.luacov
@@ -1,2 +1,2 @@
-include = {'./lua/*'}
-exclude = {'./lua/vendor/*', '/opt', '/usr', 'tests'}
+include = {'lua/*'}
+exclude = {'lua/vendor/*', '/opt', '/usr', 'tests', 'luarocks', 'resty_modules'}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ env:
 services:
     - docker
 
+before_install:
+    - sudo apt-get install luarocks lua5.1
+    - wget -qO - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
+    - sudo add-apt-repository -y "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main"
+    - sudo apt-get update && sudo apt-get install -y openresty openresty-opm openresty-resty
+
 before_script:
     - make cook-image
 

--- a/Dockerfile.opensource
+++ b/Dockerfile.opensource
@@ -37,26 +37,15 @@ RUN dpkg -i dumb-init_*.deb
 
 RUN apt-get clean
 
-# We directly pin both lua dependencies to allow for reproducible
-# deploy builds.
-RUN luarocks install lyaml 6.1.1-4
-RUN luarocks install luasocket 3.0rc1-2
-RUN luarocks install luafilesystem 1.6.3-2
-RUN luarocks install lua-resty-http 0.12-0
-RUN luarocks install crc32 1.0
-RUN luarocks install busted 2.0.rc12-1
-RUN luarocks install cluacov
-RUN luarocks install luacheck
-RUN opm get detailyang/lua-resty-rfc5424=0.1.0
-
 RUN mkdir -p /code
+RUN mkdir -p /code/logs
 WORKDIR /code
 
-# Revert after https://github.com/thibaultcha/lua-cassandra/pull/104 gets merged.
-ADD lua-cassandra-dev-0.rockspec lua-cassandra-dev-0.rockspec
-RUN luarocks build lua-cassandra-dev-0.rockspec
+ADD casper-dev-0.rockspec lua-cassandra-dev-0.rockspec opm-dependencies.txt Makefile /code/
+RUN make deps
 
 ADD . /code
+
 RUN chown -R nobody:nogroup /code /usr/local/openresty
 
 # See https://github.com/moby/moby/issues/2259

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ remnants of "Spectre" in the code, that's why!
 * `docker`: make sure it's installed on your system by following the
 instruction for your platform [here](https://docs.docker.com/install/).
 * `make`: ensure you can run `make` targets with your OS (on Windows, use `nmake`.)
+* `lua 5.1`
+* `luarocks`
+* `openresty`: follow the instructions at https://openresty.org/en/installation.html
+
+On macos you can install most of those packages easily via homebrew (https://brew.sh/).
+Just run `brew install lua@5.1 openresty/brew/openresty luarocks make`.
 
 ## Building locally
 
@@ -26,18 +32,13 @@ To start Casper, run
 
 To make sure it's up (change the port accordingly if you change the default):
 
-    $ curl -v localhost:32927/status
+    $ curl -v localhost:8888/status
 
 For basic debugging (is it missing/hitting the cache? Am I being correctly
 proxied? etc), curl, and pay attention to the "Spectre-Cache-Status" header:
 
     $ curl -o /dev/null -iv -H 'X-Source-Id: test' -H 'X-Smartstack-Destination: yelp-main.internalapi' -H 'X-Smartstack-Source: spectre.main' -H 'Host: internalapi' 'localhost:32927/category_yelp/?locale=en_US' 2>&1 | grep 'Spectre-Cache-Status'
     < Spectre-Cache-Status: hit
-
-To debug deeper it's highly recommended that you hop in the docker container
-in which nginx/lua are running with:
-
-    $ make inspect
 
 It can help, to get as much information as possible, to set nginx logging to
 debug granularity. In `nginx.conf`, replace the `error_log` directive by:

--- a/casper-dev-0.rockspec
+++ b/casper-dev-0.rockspec
@@ -1,0 +1,28 @@
+package = "casper"
+version = "dev-0"
+source = {
+  url = "git://github.com/Yelp/casper",
+}
+description = {
+  summary = "Casper (a friendly Spectre)",
+  homepage = "https://github.com/Yelp/casper",
+  license = "Apache"
+}
+-- List all 3rd party dependencies that we need
+dependencies = {
+  "busted == 2.0.0-1",
+  "cluacov == 0.1.1-1",
+  "crc32 == 1.1-1",
+  "lua-resty-http == 0.15-0",
+  "lua-resty-lock == 0.08-0",
+  "luacheck == 0.23.0-1",
+  "luafilesystem == 1.7.0-2",
+  "luasocket == 3.0rc1-2",
+  "lyaml == 6.2.4-1",
+}
+-- We don't have any c file so there's nothing to compile,
+-- however the build target is mandatory.
+build = {
+  type = "builtin",
+  modules = {}
+}

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -11,7 +11,8 @@ events {
 
 http {
     # Set lua search path
-    lua_package_path '/code/lua/?.lua;;';
+    lua_package_path '/usr/local/openresty/lualib/?.lua;luarocks/share/lua/5.1/?.lua;luarocks/share/lua/5.1/?/init.lua;resty_modules/lualib/?.lua;lua/?.lua;';
+    lua_package_cpath 'luarocks/lib/lua/5.1/?.so;;';
 
     # Log to stderr, so we can see stacktraces in PaaSTA logs
     error_log /dev/stderr error;
@@ -55,7 +56,7 @@ http {
         listen 8888;
 
         location / {
-            content_by_lua_file /code/lua/entry_point.lua;
+            content_by_lua_file lua/entry_point.lua;
         }
     }
 }

--- a/luawrapper
+++ b/luawrapper
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Based on the output on `luarocks path`, but adjusted for a local
+# installation.
+export LUA_PATH='luarocks/share/lua/5.1/?.lua;luarocks/share/lua/5.1/?/init.lua;resty_modules/lualib/?.lua;lua/?.lua'
+export LUA_CPATH='luarocks/lib/lua/5.1/?.so'
+
+# Put luarocks on the PATH.
+export PATH="$(readlink -f luarocks/bin):$PATH"
+
+exec "luarocks/bin/$1" "${@:2}"

--- a/opm-dependencies.txt
+++ b/opm-dependencies.txt
@@ -1,0 +1,1 @@
+detailyang/lua-resty-rfc5424=0.1.0

--- a/start.sh
+++ b/start.sh
@@ -5,7 +5,7 @@ SERVICES_YAML_PATH=${SERVICES_YAML_PATH:-/nail/etc/services/services.yaml}
 CASSANDRA_CLUSTER_CONFIG=${CASSANDRA_CLUSTER_CONFIG:-/var/run/synapse/services/cassandra_spectre.main.json}
 # We run 1 worker per container in production
 WORKER_PROCESSES=${WORKER_PROCESSES:-1}
-NGINX_CONF=/code/config/nginx.conf
+NGINX_CONF=config/nginx.conf
 
 if [ $ACCEPTANCE ]; then
     # Cassandra ip is automatically generated
@@ -25,12 +25,13 @@ if [ "$DISABLE_STDOUT_ACCESS_LOG" = "1" ]; then
     # Let's exit if the substitution doesn't go exactly as planned
     [[ ! $? == 0 ]] && echo "error disabling stdout access_logs" && exit 1
     echo "done"
-else
-    echo "Set env var DISABLE_STDOUT_ACCESS_LOG to 1 to disable stdout access logging"
 fi
+
+echo "Starting casper"
 
 SRV_CONFIGS_PATH=$SRV_CONFIGS_PATH \
     SERVICES_YAML_PATH=$SERVICES_YAML_PATH \
     /usr/local/openresty/nginx/sbin/nginx \
         -c $NGINX_CONF \
+        -p $(pwd) \
         -g "worker_processes $WORKER_PROCESSES;"

--- a/tests/data/srv-configs/casper.internal.yaml
+++ b/tests/data/srv-configs/casper.internal.yaml
@@ -1,5 +1,5 @@
 cassandra:
-    seeds_file: '/code/tests/data/synapse/services/cassandra_casper.main.json'
+    seeds_file: 'tests/data/synapse/services/cassandra_casper.main.json'
     connect_timeout_ms: 100
     default_num_buckets: 1000
     keyspace: 'spectre_db'
@@ -15,7 +15,7 @@ http:
     timeout_ms: 10000
 
 yelp_meteorite:
-    etc_path: '/code/tests/data/etc'
+    etc_path: 'tests/data/etc'
     metrics-relay:
         host: 127.0.0.1
         port: 1234

--- a/tests/lua/config_loader_test.lua
+++ b/tests/lua/config_loader_test.lua
@@ -42,9 +42,9 @@ describe("config_loader", function()
 
     it("returns nil and log if config file is missing", function()
         stub(ngx, 'log')
-        local config = config_loader.parse_configs('/code/tests/data/srv-configs/missing_config.yaml')
+        local config = config_loader.parse_configs('tests/data/srv-configs/missing_config.yaml')
         assert.is_nil(config)
-        assert.stub(ngx.log).was.called.with(ngx.ERR, 'File missing, cannot parse: /code/tests/data/srv-configs/missing_config.yaml')
+        assert.stub(ngx.log).was.called.with(ngx.ERR, 'File missing, cannot parse: tests/data/srv-configs/missing_config.yaml')
     end)
 
     it("file has not changed, returns nil", function()

--- a/tests/lua/datastores_test.lua
+++ b/tests/lua/datastores_test.lua
@@ -30,7 +30,7 @@ describe('cassandra_helper', function()
         metrics_helper = require 'metrics_helper'
 
         config_loader = require 'config_loader'
-        config_loader.load_services_configs('/code/tests/data/srv-configs')
+        config_loader.load_services_configs('tests/data/srv-configs')
         configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['cassandra']
 
         stub(ngx, 'log')

--- a/tests/lua/metrics_helper_test.lua
+++ b/tests/lua/metrics_helper_test.lua
@@ -5,7 +5,7 @@ describe("metrics_helper", function()
 
     setup(function()
         config_loader = require 'config_loader'
-        config_loader.load_services_configs('/code/tests/data/srv-configs')
+        config_loader.load_services_configs('tests/data/srv-configs')
         configs = config_loader.get_spectre_config_for_namespace(config_loader.CASPER_INTERNAL_NAMESPACE)['yelp_meteorite']
 
         stub(ngx, 'log')

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -20,7 +20,7 @@ describe("spectre_common", function()
         }
 
         config_loader = require 'config_loader'
-        config_loader.load_services_configs('/code/tests/data/srv-configs')
+        config_loader.load_services_configs('tests/data/srv-configs')
         spectre_common = require 'spectre_common'
 
         stub(ngx, 'log')
@@ -29,7 +29,7 @@ describe("spectre_common", function()
     describe("spectre_common", function()
         before_each(function()
             config_loader.clear_mod_time_table()
-            config_loader.load_services_configs('/code/tests/data/srv-configs')
+            config_loader.load_services_configs('tests/data/srv-configs')
         end)
 
         it("disable caching via configs", function()

--- a/tests/lua/zipkin_test.lua
+++ b/tests/lua/zipkin_test.lua
@@ -8,7 +8,7 @@ describe("zipkin", function()
         zipkin = require 'zipkin'
 
         config_loader = require 'config_loader'
-        config_loader.load_services_configs('/code/tests/data/srv-configs')
+        config_loader.load_services_configs('tests/data/srv-configs')
 
         stub(ngx, 'log')
     end)


### PR DESCRIPTION
With this change unit tests will run locally and not inside docker. This also allows you to run casper locally which greatly increases debugging speed since you don't have to deal with docker.

luarocks dependencies are now installed under luarocks/ and no longer system wide, so that we don't mess up the devbox or laptop.

The luawrapper script and luarocks make target have been mostly copied from the routing service. However I'm using the system luarocks instead of building it myself since crc32 won't install with a manually built luarocks since it has some weird build incompatibility with luajit.

```
drolando@dev128-uswest1adevc casper (git run_tests_locally) ✓
~>  make test
rm -f luacov.stats.out luacov.report.out
Running tests for tests/lua/caching_handlers_test.lua
●●●●●●●●●●●●●●●●●●●●●●●●●●
26 successes / 0 failures / 0 errors / 0 pending : 0.094569 seconds
Running tests for tests/lua/config_loader_test.lua
●●●●●●●●●
9 successes / 0 failures / 0 errors / 0 pending : 0.040513 seconds
Running tests for tests/lua/datastores_test.lua
●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●
32 successes / 0 failures / 0 errors / 0 pending : 0.514916 seconds
Running tests for tests/lua/internal_handlers_test.lua
●●●●
4 successes / 0 failures / 0 errors / 0 pending : 0.014849 seconds
Running tests for tests/lua/metrics_helper_test.lua
●●
2 successes / 0 failures / 0 errors / 0 pending : 0.009002 seconds
Running tests for tests/lua/nginx_test.lua
●
1 success / 0 failures / 0 errors / 0 pending : 0.062345 seconds
Running tests for tests/lua/spectre_common_test.lua
●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●
57 successes / 0 failures / 0 errors / 0 pending : 0.389367 seconds
Running tests for tests/lua/traceback_test.lua
●
1 success / 0 failures / 0 errors / 0 pending : 0.001295 seconds
Running tests for tests/lua/zipkin_test.lua
●●●●●
5 successes / 0 failures / 0 errors / 0 pending : 0.010705 seconds
./luawrapper luacheck lua --exclude-files lua/vendor/*
Checking lua/bulk_endpoints.lua                   OK
Checking lua/caching_handlers.lua                 OK
Checking lua/config_loader.lua                    OK
Checking lua/datastores.lua                       OK
Checking lua/entry_point.lua                      OK
Checking lua/http.lua                             OK
Checking lua/internal_handlers.lua                OK
Checking lua/itest_post_request_handlers.lua      OK
Checking lua/main.lua                             OK
Checking lua/metrics_helper.lua                   OK
Checking lua/spectre_common.lua                   OK
Checking lua/traceback.lua                        OK
Checking lua/util.lua                             OK
Checking lua/zipkin.lua                           OK

Total: 0 warnings / 0 errors in 14 files
./luawrapper luacov
==============================================================================

File                      Hits Missed Coverage
----------------------------------------------
lua/bulk_endpoints.lua    10   94     9.62%
lua/caching_handlers.lua  146  2      98.65%
lua/config_loader.lua     68   7      90.67%
lua/datastores.lua        195  11     94.66%
lua/http.lua              5    8      38.46%
lua/internal_handlers.lua 30   57     34.48%
lua/metrics_helper.lua    50   34     59.52%
lua/spectre_common.lua    245  38     86.57%
lua/traceback.lua         6    0      100.00%
lua/util.lua              4    22     15.38%
lua/zipkin.lua            28   35     44.44%
----------------------------------------------
Total                     787  308    71.87%
```