### PR TITLE
use newer lua cassandra

### DIFF
--- a/itest/casper/Dockerfile
+++ b/itest/casper/Dockerfile
@@ -1,0 +1,7 @@
+ARG CASPER_IMAGE
+FROM ${CASPER_IMAGE}
+
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /tmp/wait-for-it.sh
+RUN chmod +x /tmp/wait-for-it.sh
+
+CMD ["sh", "-c", "/tmp/wait-for-it.sh --timeout=90 $WAIT_ON -- /code/start.sh"]

--- a/itest/docker-compose.yml
+++ b/itest/docker-compose.yml
@@ -4,7 +4,10 @@ services:
     spectre:
         cap_add:
             - NET_ADMIN
-        image: ${DOCKER_TAG}
+        build:
+            context: ./casper
+            args:
+                CASPER_IMAGE: ${DOCKER_TAG}
         depends_on:
             - syslog
             - metrics
@@ -15,6 +18,7 @@ services:
             - SERVICES_YAML_PATH=/code/itest/data/services.yaml
             - WORKER_PROCESSES=1
             - DISABLE_STDOUT_ACCESS_LOG=1
+            - WAIT_ON=10.5.0.5:9042
         volumes:
             - /var/log/nginx
             - ./data/etc:/nail/etc:ro

--- a/itest/test/Dockerfile
+++ b/itest/test/Dockerfile
@@ -3,6 +3,7 @@ LABEL   maintainer="Yelp Performance Team"
 
 RUN     DEBIAN_FRONTEND=noninteractive apt-get update \
         && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            curl \
             python3-dev \
             python3-setuptools \
             virtualenv \
@@ -20,5 +21,10 @@ RUN     pip install -U \
 COPY    requirements.txt requirements.txt
 RUN     pip install -r requirements.txt
 
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /tmp/wait-for-it.sh
+RUN chmod +x /tmp/wait-for-it.sh
+
 COPY    . /code
 RUN     chmod 777 -R /code
+
+ENTRYPOINT ["/tmp/wait-for-it.sh", "10.5.0.2:8888", "--"]

--- a/itest/test/spectre/conftest.py
+++ b/itest/test/spectre/conftest.py
@@ -13,10 +13,12 @@ def wait_for_casper():
     while the tests usually start immediately without waiting.
     """
     for i in range(60):
-        response = get_from_spectre('/status?check_cassandra=true')
-        if response.status_code == 200:
-            return
-        else:
-            time.sleep(1)
+        try:
+            response = get_from_spectre('/status?check_cassandra=true')
+            if response.status_code == 200:
+                return
+        except Exception:
+            pass
+        time.sleep(1)
     else:
         raise RuntimeError("Spectre was not ready after 60 seconds")

--- a/lua-cassandra-dev-0.rockspec
+++ b/lua-cassandra-dev-0.rockspec
@@ -4,7 +4,7 @@ version = "dev-0"
 -- https://github.com/thibaultcha/lua-cassandra/pull/104
 source = {
   url = "git://github.com/drolando/lua-cassandra",
-  branch = "add_stream_id_support_dev"
+  branch = "add_stream_id_1_5_0_lua_master"
 }
 description = {
   summary = "A pure Lua client library for Apache Cassandra",
@@ -25,7 +25,9 @@ build = {
     ["resty.cassandra.cluster"] = "lib/resty/cassandra/cluster.lua",
     ["resty.cassandra.policies.lb"] = "lib/resty/cassandra/policies/lb/init.lua",
     ["resty.cassandra.policies.lb.rr"] = "lib/resty/cassandra/policies/lb/rr.lua",
+    ["resty.cassandra.policies.lb.req_rr"] = "lib/resty/cassandra/policies/lb/req_rr.lua",
     ["resty.cassandra.policies.lb.dc_rr"] = "lib/resty/cassandra/policies/lb/dc_rr.lua",
+    ["resty.cassandra.policies.lb.req_dc_rr"] = "lib/resty/cassandra/policies/lb/req_dc_rr.lua",
     ["resty.cassandra.policies.reconnection"] = "lib/resty/cassandra/policies/reconnection/init.lua",
     ["resty.cassandra.policies.reconnection.exp"] = "lib/resty/cassandra/policies/reconnection/exp.lua",
     ["resty.cassandra.policies.reconnection.const"] = "lib/resty/cassandra/policies/reconnection/const.lua",

--- a/lua/datastores.lua
+++ b/lua/datastores.lua
@@ -61,9 +61,8 @@ function cassandra_helper.get_cluster_hosts()
                 -- If host is not an ip, resolve it
                 host = socket.dns.toip(host)
             end
-            table.insert(hosts, string.format('%s:%s',
-                host,
-                v['port']
+            table.insert(hosts, string.format('%s',
+                host
             ))
         end
     end
@@ -104,6 +103,7 @@ function cassandra_helper.create_cluster(cluster_module, shm, timeout)
         timeout_connect = tonumber(configs['connect_timeout_ms']),
         timeout_read = timeout,
         retry_on_timeout = configs['retry_on_timeout'],
+        default_port = 9042,
         retry_policy = cassandra_helper.retry_policy(configs['num_retries'])
     }
 

--- a/tests/lua/datastores_test.lua
+++ b/tests/lua/datastores_test.lua
@@ -39,7 +39,7 @@ describe('cassandra_helper', function()
     describe('get_cluster_hosts', function()
         it('returns the Cassandra connection string', function()
             local actual = cassandra_helper.get_cluster_hosts()
-            local expected = {'10.56.6.22:31321','10.40.25.42:31725'}
+            local expected = {'10.56.6.22','10.40.25.42'}
 
             assert.are.same(expected, actual)
         end)
@@ -48,7 +48,7 @@ describe('cassandra_helper', function()
             local old_region = configs['local_region']
             configs['local_region'] = 'uswest1'
             local actual = cassandra_helper.get_cluster_hosts()
-            local expected = {'10.40.25.42:31725' }
+            local expected = {'10.40.25.42' }
             configs['local_region'] = old_region
 
             assert.are.same(expected, actual)
@@ -84,7 +84,7 @@ describe('cassandra_helper', function()
         local cluster_module = {
             new = function(opts)
                 assert.are.equal('test_shm', opts['shm'])
-                assert.are.same({'10.56.6.22:31321','10.40.25.42:31725'}, opts['contact_points'])
+                assert.are.same({'10.56.6.22','10.40.25.42'}, opts['contact_points'])
                 assert.are.equal(configs['keyspace'], opts['keyspace'])
                 assert.are.equal(10 / 1000, opts['lock_timeout'])
                 assert.are.equal(configs['connect_timeout_ms'], opts['timeout_connect'])


### PR DESCRIPTION
The main change here is upgrading to `lua-cassandra==1.5.0`.

There was some change in what arguments the library expects as it doesn't like it anymore if we pass the seeds nodes as `ip:port` and instead only wants ips.  Passing also the port causes something in the code to get confused and the first node (the one used to discover the cluster) ends up with its `data_center` property being `nil`.

Also the new version doesn't like that we initialize the cluster object before cassandra is up, so I've added the `wait-for-it.sh` script that will wait up to 90 seconds until something starts listening on the target ip:port

FYI @thibaultcha