### PR TITLE
Expose nginx-status endpoint

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -56,6 +56,11 @@ http {
     server {
         listen 8888;
 
+        # Provide some nginx stats to the fullerite collector
+        location /nginx-status {
+            stub_status on;
+        }
+
         location / {
             content_by_lua_file lua/entry_point.lua;
         }

--- a/itest/test/spectre/internal_spectre_test.py
+++ b/itest/test/spectre/internal_spectre_test.py
@@ -45,6 +45,11 @@ class TestCanReachStatuses(object):
             },
         }
 
+    def test_can_reach_nginx_status(self):
+        response = get_from_spectre('/nginx-status')
+        assert response.status_code == 200
+        assert 'Active connections'  in response.text
+
 
 class TestConfigs(object):
 


### PR DESCRIPTION
This will let us emit metrics on how many connections each instance in
handling and whether it's overloaded (e.g. connections in waiting
status).