### PR TITLE
Fix clone_table function

### DIFF
--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -251,7 +251,11 @@ local function get_smartstack_destination(headers)
 end
 
 local function clone_table(tbl)
-  return {unpack(tbl)}
+  local new_tbl = {}
+  for k, v in pairs(tbl) do
+    new_tbl[k] = v
+  end
+  return new_tbl
 end
 
 local function get_target_uri(request_uri, request_headers)
@@ -614,6 +618,7 @@ return {
     add_zipkin_headers_to_response_headers = add_zipkin_headers_to_response_headers,
     get_smartstack_destination = get_smartstack_destination,
     get_response_from_remote_service = get_response_from_remote_service,
+    clone_table = clone_table,
     get_target_uri = get_target_uri,
     is_header_hop_by_hop = is_header_hop_by_hop,
     is_header_uncacheable = is_header_uncacheable,

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -570,6 +570,29 @@ describe("spectre_common", function()
 
     end)
 
+    describe("clone_table", function()
+        it("works with empty table", function()
+            assert.are.same({}, spectre_common.clone_table({}))
+        end)
+
+        it("doesn't drop existing key/values", function()
+            assert.are.same(
+                {key1 = 'val1', key2 = 'val2'},
+                spectre_common.clone_table({key1 = 'val1', key2 = 'val2'})
+            )
+        end)
+
+        it("works with lists as value", function()
+            tbl =  {key1 = {'val1', 'val2'}}
+            new_tbl = spectre_common.clone_table(tbl)
+            assert.are.same(tbl, new_tbl)
+            -- clone_table does a shallow copy, so the pointer to the list keeps
+            -- pointing to the exact same list. That's why I'm using `equal` rather
+            -- than `same` here.
+            assert.are.equal(tbl['key1'], new_tbl['key1'])
+        end)
+    end)
+
     describe("get_target_uri", function()
         it("Contructs a full URI based on service host/port", function()
             config_loader.set_smartstack_info_for_namespace('srv.main', {
@@ -613,6 +636,7 @@ describe("spectre_common", function()
             assert.are.equal('http://169.254.255.254:1337/quux', uri)
             -- Let's make sure we haven't mutated the original headers
             assert.are.equal('srv.main', new_headers['Host'])
+            assert.are.equal('srv.main', new_headers['X-Smartstack-Destination'])
             assert.is_nil(headers['Host'])
         end)
     end)


### PR DESCRIPTION
The clone_table function I copied from the official docs doesn't work. The new table is empty.

This simple for loop is enough to create a shallow copy and this time I've also added better tests to make sure it's working