### PR TITLE
Header keys are case insensitive

### DIFF
--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -11,10 +11,10 @@ json.decodeNumbersAsObjects = true
 json.strictTypes = true
 
 local PLEASE_DO_NOT_CACHE_HEADERS = {
-    ['X-Strongly-Consistent-Read']={'1', 'true'},
-    ['X-Force-Master-Read']={'1', 'true'},
-    ['Cache-Control']={'no-cache'},
-    ['Pragma']={'no-cache', 'spectre-no-cache'},
+    ['x-strongly-consistent-read']={'1', 'true'},
+    ['x-force-master-read']={'1', 'true'},
+    ['cache-control']={'no-cache'},
+    ['pragma']={'no-cache', 'spectre-no-cache'},
 }
 
 local HEADERS = {
@@ -24,7 +24,7 @@ local HEADERS = {
 }
 
 local SUPPORTED_ENCODING_FOR_ID_EXTRACTION = {
-    ['Content-Type']={'application/json'}
+    ['content-type']={'application/json'}
 }
 
 local DEFAULT_REQUEST_METHOD = 'GET'
@@ -63,10 +63,18 @@ end
 -- Helper function to check if available header value
 -- satisfies the comparison function for marker header lists.
 local function _check_headers_helper(headers, marker_header_list, compare_fn)
+    -- Header keys are case insensitive and you can mix - and _ at will
+    -- So let's first normalize them to lowercase and with -
+    -- We're also normalizing the header values here just to be sure, since
+    -- anyway we only care about some very specific headers.
+    local normalized_headers = {}
+    for k, v in pairs(headers) do
+        local norm_key = string.gsub(tostring(k):lower(), "_", "-")
+        normalized_headers[norm_key] = tostring(v):lower()
+    end
     for header, values in pairs(marker_header_list) do
         for _, v in pairs(values) do
-            local lowercase_header_value = tostring(headers[header]):lower()
-            if compare_fn(lowercase_header_value, v) then
+            if compare_fn(normalized_headers[header], v) then
                 return true
             end
         end

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -559,6 +559,12 @@ describe("spectre_common", function()
 
                 headers = {['Content-Type']='application/json; charset=utf-16'}
                 assert.is_true(spectre_common.has_supported_content_type(headers))
+
+                headers = {['content-type']='application/json; charset=utf-16'}
+                assert.is_true(spectre_common.has_supported_content_type(headers))
+
+                headers = {['content-type']='Application/JSON; charset=utf-16'}
+                assert.is_true(spectre_common.has_supported_content_type(headers))
             end)
 
             it("doesn't match other content type", function()


### PR DESCRIPTION
When we check whether the pragma no-cache header or the context-type
headers are set we need to remember that header keys are case
insensitive and that they're also - vs _ insensitive.

For some reason envoy lowercases all response headers, breaking this
logic if we don't handle them properly.