### PR TITLE
Stop cloning the request headers

### DIFF
--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -258,14 +258,6 @@ local function get_smartstack_destination(headers)
     return headers['X-Smartstack-Destination']
 end
 
-local function clone_table(tbl)
-  local new_tbl = {}
-  for k, v in pairs(tbl) do
-    new_tbl[k] = v
-  end
-  return new_tbl
-end
-
 local function get_target_uri(request_uri, request_headers)
     local casper_configs = config_loader.get_spectre_config_for_namespace(
         config_loader.CASPER_INTERNAL_NAMESPACE
@@ -275,12 +267,9 @@ local function get_target_uri(request_uri, request_headers)
         local envoy_configs = config_loader.get_spectre_config_for_namespace(
             config_loader.ENVOY_NAMESPACE
         )
-        -- Do not mutate the original headers since they're used as part of the
-        -- cache key. Let's make a copy instead and change that.
-        local new_headers = clone_table(request_headers)
-        new_headers['Host'] = destination
+        request_headers['Host'] = destination
         -- in envoy_configs['url'], we have a '/' at the end of the url, so we need to remove it from request_url
-        return envoy_configs['url'] .. string.sub(request_uri, 2), new_headers
+        return envoy_configs['url'] .. string.sub(request_uri, 2), request_headers
     else
         local info = config_loader.get_smartstack_info_for_namespace(destination)
         local host = info['host']
@@ -626,7 +615,6 @@ return {
     add_zipkin_headers_to_response_headers = add_zipkin_headers_to_response_headers,
     get_smartstack_destination = get_smartstack_destination,
     get_response_from_remote_service = get_response_from_remote_service,
-    clone_table = clone_table,
     get_target_uri = get_target_uri,
     is_header_hop_by_hop = is_header_hop_by_hop,
     is_header_uncacheable = is_header_uncacheable,

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -267,7 +267,7 @@ local function get_target_uri(request_uri, request_headers)
         local envoy_configs = config_loader.get_spectre_config_for_namespace(
             config_loader.ENVOY_NAMESPACE
         )
-        request_headers['Host'] = destination
+        request_headers['X-Yelp-Svc'] = destination
         -- in envoy_configs['url'], we have a '/' at the end of the url, so we need to remove it from request_url
         return envoy_configs['url'] .. string.sub(request_uri, 2), request_headers
     else

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -576,29 +576,6 @@ describe("spectre_common", function()
 
     end)
 
-    describe("clone_table", function()
-        it("works with empty table", function()
-            assert.are.same({}, spectre_common.clone_table({}))
-        end)
-
-        it("doesn't drop existing key/values", function()
-            assert.are.same(
-                {key1 = 'val1', key2 = 'val2'},
-                spectre_common.clone_table({key1 = 'val1', key2 = 'val2'})
-            )
-        end)
-
-        it("works with lists as value", function()
-            tbl =  {key1 = {'val1', 'val2'}}
-            new_tbl = spectre_common.clone_table(tbl)
-            assert.are.same(tbl, new_tbl)
-            -- clone_table does a shallow copy, so the pointer to the list keeps
-            -- pointing to the exact same list. That's why I'm using `equal` rather
-            -- than `same` here.
-            assert.are.equal(tbl['key1'], new_tbl['key1'])
-        end)
-    end)
-
     describe("get_target_uri", function()
         it("Contructs a full URI based on service host/port", function()
             config_loader.set_smartstack_info_for_namespace('srv.main', {
@@ -640,10 +617,8 @@ describe("spectre_common", function()
                 headers
             )
             assert.are.equal('http://169.254.255.254:1337/quux', uri)
-            -- Let's make sure we haven't mutated the original headers
             assert.are.equal('srv.main', new_headers['Host'])
             assert.are.equal('srv.main', new_headers['X-Smartstack-Destination'])
-            assert.is_nil(headers['Host'])
         end)
     end)
 

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -617,7 +617,7 @@ describe("spectre_common", function()
                 headers
             )
             assert.are.equal('http://169.254.255.254:1337/quux', uri)
-            assert.are.equal('srv.main', new_headers['Host'])
+            assert.are.equal('srv.main', new_headers['X-Yelp-Svc'])
             assert.are.equal('srv.main', new_headers['X-Smartstack-Destination'])
         end)
     end)


### PR DESCRIPTION
Since this is the only difference between haproxy and envoy I'm quite
sure that this is what's causing the weird errors in prod.

Turns out that Host is not a vary-header for any service and so it's
never part of any cache key, so it should be fine to mutate the request
headers.