### PR TITLE
refresh cassandra topology using timer

### DIFF
--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -53,8 +53,6 @@ function caching_handlers._post_request_callback(response, request_info, cacheab
     local cache_uri = caching_handlers._get_cache_uri(request_info)
     local success, err = xpcall(
         function()
-            -- Refresh cluster topology before writing the result
-            cassandra_helper.refresh()
 
             spectre_common.cache_store(
                 cassandra_helper,

--- a/lua/config_loader.lua
+++ b/lua/config_loader.lua
@@ -8,7 +8,7 @@ local ENVOY_CONFIGS_PATH = os.getenv('ENVOY_CONFIGS_PATH')
 local CASPER_INTERNAL_NAMESPACE = 'casper.internal'
 local ENVOY_NAMESPACE = 'envoy_client'
 
-local RELOAD_DELAY = 30  -- seconds
+local RELOAD_DELAY = 10  -- seconds
 
 -- _mod_time_table keeps track of files and their last modification time to
 -- trigger reload only if files change

--- a/lua/config_loader.lua
+++ b/lua/config_loader.lua
@@ -153,6 +153,10 @@ local function reload_configs(premature)
     load_services_configs(SRV_CONFIGS_PATH)
     load_smartstack_info(SERVICES_YAML_PATH)
 
+    -- Refresh cluster topology
+    ngx.shared.cassandra_write_cluster:refresh()
+    ngx.shared.cassandra_read_cluster:refresh()
+
     -- https://github.com/openresty/lua-nginx-module#ngxtimerat
     if premature then
         return

--- a/lua/config_loader.lua
+++ b/lua/config_loader.lua
@@ -155,7 +155,22 @@ local function reload_configs(premature)
 
     -- Refresh cluster topology
     ngx.shared.cassandra_write_cluster:refresh()
-    ngx.shared.cassandra_read_cluster:refresh()
+    local ok, err, topology = ngx.shared.cassandra_read_cluster:refresh()
+      if not ok then
+        ngx.log(ngx.ERR, "[cassandra] failed to refresh cluster topology: ",
+                         err)
+
+      elseif topology then
+        if #topology.added > 0 then
+          ngx.log(ngx.NOTICE, "[cassandra] peers added to cluster topology: ",
+                              table.concat(topology.added, ", "))
+        end
+
+        if #topology.removed > 0 then
+          ngx.log(ngx.NOTICE, "[cassandra] peers removed from cluster topology: ",
+                              table.concat(topology.removed, ", "))
+        end
+      end
 
     -- https://github.com/openresty/lua-nginx-module#ngxtimerat
     if premature then


### PR DESCRIPTION
@drolando this is the change i'm going to deploy to spectre's dev.everything deploy group to test.

I initially tried using the functions from `lua/datastores.lua` however, requiring the datastores module in config_loader introduced a circular dependency between these two modules.

If we decide to move forward with this patch after testing in dev, I'll look at:
- Writing appropriate tests 
- Removing the logic to call refresh() after executing a CQL query
- Extracting parts of the datastores module into a separate module that can be required by datastores and config_loade