### PR TITLE
Move the error destination config line from section http to main

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -6,6 +6,9 @@ env PAASTA_SERVICE;
 env SERVICES_YAML_PATH;
 env SRV_CONFIGS_PATH;
 
+# Log to stderr, so we can see stacktraces in PaaSTA logs
+error_log /dev/stderr error;
+
 events {
     worker_connections 4096;
 }
@@ -14,9 +17,6 @@ http {
     # Set lua search path
     lua_package_path '/usr/local/openresty/lualib/?.lua;luarocks/share/lua/5.1/?.lua;luarocks/share/lua/5.1/?/init.lua;resty_modules/lualib/?.lua;lua/?.lua;';
     lua_package_cpath 'luarocks/lib/lua/5.1/?.so;;';
-
-    # Log to stderr, so we can see stacktraces in PaaSTA logs
-    error_log /dev/stderr error;
 
     log_format main_spectre '{"time_iso8601": "$time_iso8601", "remote_addr": "$remote_addr", "connection": "$connection", "connection_requests": "$connection_requests", "http_user_agent": "$http_user_agent", "status": "$status", "request_length": "$request_length", "bytes_sent": "$bytes_sent", "request_time": "$request_time", "request_uri": "$request_uri", "unix_time": "$msec", "x_smartstack_source": "$http_x_smartstack_source", "x_smartstack_destination": "$http_x_smartstack_destination", "spectre_cache_status": "$sent_http_spectre_cache_status"}';
     # Update start.sh script if you change next line


### PR DESCRIPTION
i think this will make all errors go to stderr (and therefore paasta_app_output) and not how it is now, where some go to `/code/logs/error.log`. i think this is all that's needed in the casper repo

make test  and make itest are both green