### PR TITLE
Adding an original status header which records the downstream response status code

### DIFF
--- a/lua/bulk_endpoints.lua
+++ b/lua/bulk_endpoints.lua
@@ -153,11 +153,7 @@ local function bulk_endpoint_caching_handler(request_info, cacheability_info)
         bulk_resp_headers_cacheable = response.cacheable_headers
         bulk_resp_headers_uncacheable = response.uncacheable_headers
         for k,v in pairs(bulk_resp_headers_uncacheable) do headers[k] = v end
-        if response.no_response then
-            headers[spectre_common.HEADERS.ORIGINAL_STATUS] = -1
-        else
-            headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
-        end
+        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.no_response and -1 or response.status
 
         -- If there's an error in the request, send back the error body
         if bulk_status ~= 200 then

--- a/lua/bulk_endpoints.lua
+++ b/lua/bulk_endpoints.lua
@@ -153,7 +153,11 @@ local function bulk_endpoint_caching_handler(request_info, cacheability_info)
         bulk_resp_headers_cacheable = response.cacheable_headers
         bulk_resp_headers_uncacheable = response.uncacheable_headers
         for k,v in pairs(bulk_resp_headers_uncacheable) do headers[k] = v end
-        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
+        if response.no_response then
+            headers[spectre_common.HEADERS.ORIGINAL_STATUS] = -1
+        else
+            headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
+        end
 
         -- If there's an error in the request, send back the error body
         if bulk_status ~= 200 then

--- a/lua/bulk_endpoints.lua
+++ b/lua/bulk_endpoints.lua
@@ -153,6 +153,7 @@ local function bulk_endpoint_caching_handler(request_info, cacheability_info)
         bulk_resp_headers_cacheable = response.cacheable_headers
         bulk_resp_headers_uncacheable = response.uncacheable_headers
         for k,v in pairs(bulk_resp_headers_uncacheable) do headers[k] = v end
+        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
 
         -- If there's an error in the request, send back the error body
         if bulk_status ~= 200 then

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -126,7 +126,6 @@ function caching_handlers._caching_handler(request_info, cacheability_info)
             'non-cacheable-response: status code is %d',
             response.status
         )
-
     end
     for k, v in pairs(response.cacheable_headers) do headers[k] = v end
 
@@ -153,9 +152,7 @@ function caching_handlers._forward_non_handleable_requests(cache_status, incomin
     local headers = response.uncacheable_headers
     headers[spectre_common.HEADERS.CACHE_STATUS] = cache_status
     headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
-
     for k, v in pairs(response.cacheable_headers) do headers[k] = v end
-
 
     return {
         status = response.status,

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -112,11 +112,7 @@ function caching_handlers._caching_handler(request_info, cacheability_info)
     )
     local post_request
     local headers = response.uncacheable_headers
-    if response.no_response then
-        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = -1
-    else
-        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
-    end
+    headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.no_response and -1 or response.status
 
     if response.status == ngx.HTTP_OK then
         headers[spectre_common.HEADERS.CACHE_STATUS] = 'miss'
@@ -155,11 +151,7 @@ function caching_handlers._forward_non_handleable_requests(cache_status, incomin
     )
     local headers = response.uncacheable_headers
     headers[spectre_common.HEADERS.CACHE_STATUS] = cache_status
-    if response.no_response then
-        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = -1
-    else
-        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
-    end
+    headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.no_response and -1 or response.status
     for k, v in pairs(response.cacheable_headers) do headers[k] = v end
 
     return {

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -110,9 +110,10 @@ function caching_handlers._caching_handler(request_info, cacheability_info)
         ngx.var.request_uri,
         ngx.req.get_headers()
     )
-
-    local headers = response.uncacheable_headers
     local post_request
+    local headers = response.uncacheable_headers
+    headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
+
     if response.status == ngx.HTTP_OK then
         headers[spectre_common.HEADERS.CACHE_STATUS] = 'miss'
         if not cached_value['cassandra_error'] then
@@ -125,7 +126,6 @@ function caching_handlers._caching_handler(request_info, cacheability_info)
             'non-cacheable-response: status code is %d',
             response.status
         )
-        headers[spectre_common.HEADERS.DOWNSTREAM_ERROR] = response.status
 
     end
     for k, v in pairs(response.cacheable_headers) do headers[k] = v end
@@ -152,9 +152,8 @@ function caching_handlers._forward_non_handleable_requests(cache_status, incomin
     )
     local headers = response.uncacheable_headers
     headers[spectre_common.HEADERS.CACHE_STATUS] = cache_status
-    if response.status ~= ngx.HTTP_OK then
-        headers[spectre_common.HEADERS.DOWNSTREAM_ERROR] = response.status
-    end
+    headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
+
     for k, v in pairs(response.cacheable_headers) do headers[k] = v end
 
 

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -141,7 +141,6 @@ end
 -- fit the caching criteria OR because of some failures
 -- @cache_status: The value of the header Spectre-Cache-Status
 -- @incoming_zipkin_headers: Headers sent in from the request
--- @original_status: The value of the header X-Original-Status
 function caching_handlers._forward_non_handleable_requests(cache_status, incoming_zipkin_headers)
     local response = spectre_common.get_response_from_remote_service(
         incoming_zipkin_headers,

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -142,7 +142,7 @@ end
 -- fit the caching criteria OR because of some failures
 -- @cache_status: The value of the header Spectre-Cache-Status
 -- @incoming_zipkin_headers: Headers sent in from the request
--- @downstream_error: The value of the header X-Downstream-Error
+-- @original_status: The value of the header X-Original-Status
 function caching_handlers._forward_non_handleable_requests(cache_status, incoming_zipkin_headers)
     local response = spectre_common.get_response_from_remote_service(
         incoming_zipkin_headers,

--- a/lua/caching_handlers.lua
+++ b/lua/caching_handlers.lua
@@ -112,7 +112,11 @@ function caching_handlers._caching_handler(request_info, cacheability_info)
     )
     local post_request
     local headers = response.uncacheable_headers
-    headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
+    if response.no_response then
+        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = -1
+    else
+        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
+    end
 
     if response.status == ngx.HTTP_OK then
         headers[spectre_common.HEADERS.CACHE_STATUS] = 'miss'
@@ -151,7 +155,11 @@ function caching_handlers._forward_non_handleable_requests(cache_status, incomin
     )
     local headers = response.uncacheable_headers
     headers[spectre_common.HEADERS.CACHE_STATUS] = cache_status
-    headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
+    if response.no_response then
+        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = -1
+    else
+        headers[spectre_common.HEADERS.ORIGINAL_STATUS] = response.status
+    end
     for k, v in pairs(response.cacheable_headers) do headers[k] = v end
 
     return {

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -317,6 +317,9 @@ local function forward_to_destination(method, request_uri, request_headers)
             body = body,
             cacheable_headers = {},
             uncacheable_headers = {},
+            -- This indicates that the origin didn't actually respond
+            -- and that any status codes are inferred
+            no_response = true
         }
     end
 
@@ -338,6 +341,7 @@ local function forward_to_destination(method, request_uri, request_headers)
         body = response.body,
         cacheable_headers = cacheable_headers,
         uncacheable_headers = uncacheable_headers,
+        no_response = false
     }
 end
 

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -21,7 +21,7 @@ local HEADERS = {
     CACHE_STATUS = 'Spectre-Cache-Status',
     B3_TRACEID = 'X-B3-TraceId',
     ZIPKIN_ID = 'X-Zipkin-Id',
-    DOWNSTREAM_ERROR = 'X-Downstream-Error'
+    ORIGINAL_STATUS = 'X-Original-Status'
 }
 
 local SUPPORTED_ENCODING_FOR_ID_EXTRACTION = {

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -605,6 +605,7 @@ local function get_response_from_remote_service(incoming_zipkin_headers, method,
         uri,
         request_headers
     )
+
     return response
 end
 

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -295,6 +295,11 @@ local function forward_to_destination(method, request_uri, request_headers)
         new_headers
     )
 
+    -- If a downstream error was encountered, record this in a response header
+    if response.status ~= ngx.HTTP_OK then
+        response.headers['x-downstream-error'] = response.status
+    end
+
     if not response then
         local body = "Error requesting " .. request_uri .. ": " .. error_message
 

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -21,6 +21,7 @@ local HEADERS = {
     CACHE_STATUS = 'Spectre-Cache-Status',
     B3_TRACEID = 'X-B3-TraceId',
     ZIPKIN_ID = 'X-Zipkin-Id',
+    DOWNSTREAM_ERROR = 'X-Downstream-Error'
 }
 
 local SUPPORTED_ENCODING_FOR_ID_EXTRACTION = {
@@ -294,11 +295,6 @@ local function forward_to_destination(method, request_uri, request_headers)
         target_uri,
         new_headers
     )
-
-    -- If a downstream error was encountered, record this in a response header
-    if response.status ~= ngx.HTTP_OK then
-        response.headers['x-downstream-error'] = response.status
-    end
 
     if not response then
         local body = "Error requesting " .. request_uri .. ": " .. error_message
@@ -609,7 +605,6 @@ local function get_response_from_remote_service(incoming_zipkin_headers, method,
         uri,
         request_headers
     )
-
     return response
 end
 

--- a/tests/lua/caching_handlers_test.lua
+++ b/tests/lua/caching_handlers_test.lua
@@ -433,7 +433,6 @@ insulate('caching_handlers', function()
                     body = 'error message',
                     cacheable_headers = {},
                     uncacheable_headers = {},
-                    no_response = false
                 }
             end
             local res = caching_handlers._caching_handler(

--- a/tests/lua/caching_handlers_test.lua
+++ b/tests/lua/caching_handlers_test.lua
@@ -413,7 +413,8 @@ insulate('caching_handlers', function()
             assert.are.same({
                 ['Header1'] = 'cacheable',
                 ['Header2'] = 'uncacheable',
-                ['Spectre-Cache-Status'] = 'miss'
+                ['Spectre-Cache-Status'] = 'miss',
+                ['X-Original-Status'] = 200
             }, res.headers)
             assert.is_not_nil(res.post_request)
         end)
@@ -443,7 +444,7 @@ insulate('caching_handlers', function()
             assert.are.equal('error message', res.body)
             assert.are.same({
                 ['Spectre-Cache-Status'] = 'non-cacheable-response: status code is 501',
-                ['X-Downstream-Error'] = 501
+                ['X-Original-Status'] = 501
             }, res.headers)
             assert.is_nil(res.post_request)
         end)
@@ -474,7 +475,8 @@ insulate('caching_handlers', function()
             assert.are.same({
                 ['Header1'] = 'cacheable',
                 ['Header2'] = 'uncacheable',
-                ['Spectre-Cache-Status'] = 'miss'
+                ['Spectre-Cache-Status'] = 'miss',
+                ['X-Original-Status'] = 200
             }, res.headers)
             assert.is_nil(res.post_request)
         end)
@@ -509,6 +511,7 @@ insulate('caching_handlers', function()
                 ['Header1'] = 'cacheable',
                 ['Header2'] = 'uncacheable',
                 ['Spectre-Cache-Status'] = 'some reason',
+                ['X-Original-Status'] = 200
             }, res.headers)
         end)
 
@@ -540,7 +543,7 @@ insulate('caching_handlers', function()
                 ['Header1'] = 'cacheable',
                 ['Header2'] = 'uncacheable',
                 ['Spectre-Cache-Status'] = 'some reason',
-                ['X-Downstream-Error'] = 500
+                ['X-Original-Status'] = 500
             }, res.headers)
         end)
     end)

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -669,6 +669,7 @@ describe("spectre_common", function()
             )
 
             assert.are.equal(200, resp.status)
+            assert.are.equal(false, resp.no_response)
             assert.are.equal('RESULT', resp.body)
         end)
 

--- a/tests/lua/spectre_common_test.lua
+++ b/tests/lua/spectre_common_test.lua
@@ -671,6 +671,23 @@ describe("spectre_common", function()
             assert.are.equal(200, resp.status)
             assert.are.equal('RESULT', resp.body)
         end)
+
+        it("Checks that no response and an error sets the appropriate return values", function()
+            _G.package.loaded.http = {
+                make_http_request = function(method, uri, body, headers)
+                    return nil, "closed"
+                end
+            }
+            local spectre_common = require 'spectre_common'
+
+            local resp = spectre_common.forward_to_destination(
+                'GET', -- method
+                '/bar', -- request_uri
+                {['X-Smartstack-Destination'] = 'srv.main'} -- request_headers
+            )
+            assert.are.equal(502, resp.status)
+            assert.are.equal(true, resp.no_response)
+        end)
     end)
 
 end)


### PR DESCRIPTION
Adding an X-Original-Status response header to improve debugging. We can later pull this data into our logs etc. This captures the status code from all downstream requests, errors or otherwise.

There is some overlap with the `CACHE_STATUS` header, although this particular header is not always present depending on the request, so there still appears to be value in having a dedicated downstream status code header.

Added for bulk endpoints also, although the code coverage in that area is very limited.

Also set the X-Original-Status header to -1 if we didn't actually get a response from the origin (but inferred the response status).

Code is passing tests (I added an extra test too):

```
Total: 0 warnings / 0 errors in 14 files
./luawrapper luacov
==============================================================================

File                      Hits Missed Coverage
----------------------------------------------
lua/bulk_endpoints.lua    10   95     9.52%
lua/caching_handlers.lua  149  2      98.68%
lua/config_loader.lua     73   7      91.25%
lua/datastores.lua        202  11     94.84%
lua/http.lua              5    8      38.46%
lua/internal_handlers.lua 30   64     31.91%
lua/metrics_helper.lua    50   34     59.52%
lua/spectre_common.lua    259  40     86.62%
lua/traceback.lua         6    0      100.00%
lua/util.lua              4    22     15.38%
lua/zipkin.lua            28   36     43.75%
----------------------------------------------
Total                     816  319    71.89%
```
You can also manually test this as follows when running `make dev`:


```
wjhoward@dev52-uswest1adevc:~$ curl -vo /dev/null -i -H 'X-Source-Id: test' -H 'X-Smartstack-Destination: yelp-main.internalapi' -H 'X-Smartstack-Source: spectre.main' -H 'Host: internalapi' 'localhost:8888/category_yelp' 2>&1 | grep "X-Original\|HTTP\|Cache"
> GET /category_yelp HTTP/1.1
< HTTP/1.1 200 OK
< Spectre-Cache-Status: non-cacheable-uri (yelp-main.internalapi)
< X-Original-Status: 200

wjhoward@dev52-uswest1adevc:~$ curl -vo /dev/null -i -H 'X-Source-Id: test' -H 'X-Smartstack-Destination: yelp-main.internalapi' -H 'X-Smartstack-Source: spectre.main' -H 'Host: internalapi' 'localhost:8888/category_yel' 2>&1 | grep "X-Original\|HTTP\|Cache"
> GET /category_yel HTTP/1.1
< HTTP/1.1 404 Not Found
< Spectre-Cache-Status: non-cacheable-uri (yelp-main.internalapi)
< X-Original-Status: 404
```
