### PR TITLE
Error logging for 5xx and -1 downstream responses, unit test improvements

### DIFF
--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -315,7 +315,7 @@ local function forward_to_destination(method, request_uri, request_headers)
 
         -- Log any "no_response" errors
         local log_error_message = HEADERS.ORIGINAL_STATUS .. ": -1, message: " .. error_message
-        log(ngx.ERR, { err=log_error_message, critical=false })
+        log(ngx.ERR, { err=log_error_message, critical=true })
 
         return {
             status = status,

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -312,6 +312,11 @@ local function forward_to_destination(method, request_uri, request_headers)
             message = error_message,
             status_code = status,
         })
+
+        -- Log any "no_response" errors
+        local log_error_message = HEADERS.ORIGINAL_STATUS .. ": -1, message: " .. error_message
+        log(ngx.ERR, { err=log_error_message, critical=false })
+
         return {
             status = status,
             body = body,
@@ -321,6 +326,12 @@ local function forward_to_destination(method, request_uri, request_headers)
             -- and that any status codes are inferred
             no_response = true
         }
+    end
+
+    -- Log any 5xx errors
+    if string.match(response.status, '5%d%d') then
+        local log_error_message = HEADERS.ORIGINAL_STATUS .. ": " .. response.status .. ", message: " .. error_message
+        log(ngx.ERR, { err=log_error_message, critical=false })
     end
 
     local cacheable_headers = {}

--- a/tests/lua/util_test.lua
+++ b/tests/lua/util_test.lua
@@ -1,0 +1,25 @@
+-- original path: casper/tests/lua
+
+require 'busted.runner'()
+
+describe('util', function()
+    local util
+
+    setup(function()
+        util = require 'util'
+    end)
+
+    it('string function should convert types', function()
+        assert.are.same(util.to_string(nil), 'nil')
+        assert.are.same(util.to_string(true), 'true')
+        assert.are.same(util.to_string(5), '5')
+        assert.are.same(util.to_string(1500000001), '1500000001(2017-07-13 19:40:01)')
+        assert.are.same(util.to_string('string'), 'string')
+        assert.are.same(util.to_string({'a', 'b'}), '[1: a;2: b;]')
+        assert.are.same(util.to_string(print), '<function>')
+    end)
+    it('non empty table function should return the correct value', function()
+        assert.are.same(util.is_non_empty_table('a'), false)
+        assert.are.same(util.is_non_empty_table({'a', 'b'}), true)
+    end)
+end)


### PR DESCRIPTION
The error log message will look similar to the following (note I temporarily adjusted the code to log a 4xx message for the output below):

```
2021/09/14 05:42:28 [error] 22449#22449: *2 [lua] spectre_common.lua:36: log():

 {"critical":false,"err":"X-Original-Status: 404, message: <error message here>"},

client: 127.0.0.1, server: , request: "GET /category_yel HTTP/1.1", host: "internalapi"
```
I did intend to update the unit tests to check that the log function was being called, but I ran into some suspected scoping issues when using the busted `spy` methods. That being said, test coverage is running over the new lines of code:

```
              -- Log any "no_response" errors
    1         local log_error_message = HEADERS.ORIGINAL_STATUS .. ": -1, message: " .. error_message
    1         log(ngx.ERR, { err=log_error_message, critical=false })
    ....
              -- Log any 5xx errors
    2     if string.match(response.status, '5%d%d') then
    1         local log_error_message = HEADERS.ORIGINAL_STATUS .. ": " .. response.status .. ", message: " .. error_message
    1         log(ngx.ERR, { err=log_error_message, critical=false })
```

**Unit tests (coverage slightly improved):**
```
Total: 0 warnings / 0 errors in 14 files
./luawrapper luacov
==============================================================================

File                      Hits Missed Coverage
----------------------------------------------
lua/bulk_endpoints.lua    10   95     9.52%
lua/caching_handlers.lua  149  2      98.68%
lua/config_loader.lua     73   7      91.25%
lua/datastores.lua        202  11     94.84%
lua/http.lua              5    8      38.46%
lua/internal_handlers.lua 30   64     31.91%
lua/metrics_helper.lua    50   34     59.52%
lua/spectre_common.lua    263  41     86.51%
lua/traceback.lua         6    0      100.00%
lua/util.lua              26   0      100.00%
lua/zipkin.lua            28   38     42.42%
----------------------------------------------
Total                     842  300    73.73%
```