### PR TITLE
Using updated lua-cassandra fork

### DIFF
--- a/lua-cassandra-dev-0.rockspec
+++ b/lua-cassandra-dev-0.rockspec
@@ -1,6 +1,7 @@
 package = "lua-cassandra"
 version = "dev-0"
 -- yelp lua-cassandra fork with stream_id support
+-- upstream original repo: https://github.com/thibaultcha/lua-cassandra
 source = {
   url = "git://github.com/yelp/lua-cassandra",
   branch = "master"

--- a/lua-cassandra-dev-0.rockspec
+++ b/lua-cassandra-dev-0.rockspec
@@ -1,10 +1,9 @@
 package = "lua-cassandra"
 version = "dev-0"
--- lua-cassandra fork with stream_id support
--- https://github.com/thibaultcha/lua-cassandra/pull/104
+-- yelp lua-cassandra fork with stream_id support
 source = {
-  url = "git://github.com/drolando/lua-cassandra",
-  branch = "add_stream_id_1_5_0_lua_master"
+  url = "git://github.com/yelp/lua-cassandra",
+  branch = "master"
 }
 description = {
   summary = "A pure Lua client library for Apache Cassandra",


### PR DESCRIPTION
Updating Casper to use the https://github.com/Yelp/lua-cassandra fork, rather than drolandos.
Said fork also uses version 1.5.1 of the upstream rather than 1.5.

The upstream changes don't seem concerning, covered here:
https://github.com/thibaultcha/lua-cassandra/blob/master/CHANGELOG.md

So far this is passing the tests:

**Unit**

```
Checking lua/bulk_endpoints.lua                   OK
Checking lua/caching_handlers.lua                 OK
Checking lua/config_loader.lua                    OK
Checking lua/datastores.lua                       OK
Checking lua/entry_point.lua                      OK
Checking lua/http.lua                             OK
Checking lua/internal_handlers.lua                OK
Checking lua/itest_post_request_handlers.lua      OK
Checking lua/main.lua                             OK
Checking lua/metrics_helper.lua                   OK
Checking lua/spectre_common.lua                   OK
Checking lua/traceback.lua                        OK
Checking lua/util.lua                             OK
Checking lua/zipkin.lua                           OK

```

**Integration**
```
93 passed, 1 warning in 74.77s (0:01:14) 
1 passed in 0.51s
```