### PR TITLE
Added DynamoDB backend support with a configurable amount of traffic, performance metric updates and associated test changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,10 +113,12 @@ dependencies = [
  "async-trait",
  "bstr",
  "bytes",
+ "chrono",
  "flexbuffers",
  "form_urlencoded",
  "futures",
  "futures-util",
+ "hex",
  "http",
  "hyper",
  "hyper_serde",
@@ -124,8 +126,11 @@ dependencies = [
  "mlua",
  "num_cpus",
  "once_cell",
+ "openssl",
  "pretty_env_logger",
  "regex",
+ "rusoto_core",
+ "rusoto_dynamodb",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -146,6 +151,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "cookie"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,12 +174,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -181,6 +235,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -229,6 +304,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -345,6 +435,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +502,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest",
 ]
 
 [[package]]
@@ -468,6 +585,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -571,6 +701,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "md-5"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,12 +777,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -696,6 +865,49 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-src"
+version = "300.0.2+3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -767,6 +979,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
 name = "pretty_env_logger"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,12 +1041,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -855,6 +1123,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ripemd160"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,10 +1143,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_core"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "lazy_static",
+ "log",
+ "rusoto_credential",
+ "rusoto_signature",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "xml-rs",
+]
+
+[[package]]
+name = "rusoto_credential"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a46b67db7bb66f5541e44db22b0a02fed59c9603e146db3a9e633272d3bac2f"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs-next",
+ "futures",
+ "hyper",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "rusoto_dynamodb"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7935e1f9ca57c4ee92a4d823dcd698eb8c992f7e84ca21976ae72cd2b03016e7"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rusoto_signature"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "digest",
+ "futures",
+ "hex",
+ "hmac",
+ "http",
+ "hyper",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "pin-project-lite",
+ "rusoto_credential",
+ "rustc_version",
+ "serde",
+ "sha2",
+ "tokio",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "ryu"
@@ -878,10 +1247,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -949,6 +1357,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1421,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -1059,6 +1506,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1164,6 +1621,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1680,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,3 +1693,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,12 @@ itest: clean-docker $(DOCKER_COMPOSE) cook-image run-itest
 .PHONY: run-itest
 run-itest: $(DOCKER_COMPOSE)
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) build
-	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) up -d spectre backend cassandra syslog
+	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) up -d spectre backend cassandra syslog localstack
+	sleep 10
+	AWS_DEFAULT_REGION="local-stack" \
+	AWS_ACCESS_KEY_ID="TEST" \
+	AWS_SECRET_ACCESS_KEY="TEST" \
+	aws dynamodb create-table --cli-input-json file://itest/create_table.json --endpoint-url http://localhost:4566 --region local-stack
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) run test python3 -m pytest -vv spectre
 	$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) exec --user=root -T spectre /opt/drop_all.sh
 	# $(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_YML) run test python3 -m pytest -vv cassandra

--- a/itest/create_table.json
+++ b/itest/create_table.json
@@ -1,0 +1,13 @@
+{
+    "TableName": "casper_cache",
+    "KeySchema": [
+      { "AttributeName": "key", "KeyType": "HASH" }
+    ],
+    "AttributeDefinitions": [
+      { "AttributeName": "key", "AttributeType": "B" }
+    ],
+    "ProvisionedThroughput": {
+      "ReadCapacityUnits": 50,
+      "WriteCapacityUnits": 50
+    }
+}

--- a/itest/data/srv-configs/casper.internal.yaml
+++ b/itest/data/srv-configs/casper.internal.yaml
@@ -12,7 +12,7 @@ cassandra:
     write_timeout_ms: 1000
 
 # Expects a value from 0 to 100, where 0 disables the dynamodb backend and 100 sends all traffic to dynamodb
-dynamodb_enabled: 1
+dynamodb_enabled_pct: 1
 
 http:
     # Lower http timeout to test that we return a 504 on timeouts

--- a/itest/data/srv-configs/casper.internal.yaml
+++ b/itest/data/srv-configs/casper.internal.yaml
@@ -11,6 +11,9 @@ cassandra:
     write_consistency: 'all'
     write_timeout_ms: 1000
 
+# Expects a value from 0 to 100, where 0 disables the dynamodb backend and 100 sends all traffic to dynamodb
+dynamodb_enabled: 1
+
 http:
     # Lower http timeout to test that we return a 504 on timeouts
     timeout_ms: 1000

--- a/itest/data/srv-configs/casper.internal.yaml
+++ b/itest/data/srv-configs/casper.internal.yaml
@@ -12,7 +12,7 @@ cassandra:
     write_timeout_ms: 1000
 
 # Expects a value from 0 to 100, where 0 disables the dynamodb backend and 100 sends all traffic to dynamodb
-dynamodb_enabled_pct: 1
+dynamodb_enabled_pct: 100
 
 http:
     # Lower http timeout to test that we return a 504 on timeouts

--- a/itest/docker-compose.yml
+++ b/itest/docker-compose.yml
@@ -20,6 +20,12 @@ services:
             - WORKER_PROCESSES=1
             - DISABLE_STDOUT_ACCESS_LOG=1
             - WAIT_ON=10.5.0.5:9042
+            - AWS_ACCESS_KEY_ID=TEST
+            - AWS_SECRET_ACCESS_KEY=TEST
+            - AWS_DEFAULT_REGION=local-stack
+            - DYNAMO_NAME=local-stack
+            - DYNAMO_ENDPOINT=http://10.5.0.10:4566
+
         volumes:
             - /var/log/nginx
             - ./data/etc:/nail/etc:ro
@@ -47,6 +53,25 @@ services:
         networks:
             spectre_net:
                 ipv4_address: 10.5.0.5
+
+    localstack:
+        container_name: "itest_localstack"
+        image: localstack/localstack
+        ports:
+            - '4566:4566'
+            - '4571:4571'
+        environment:
+            - SERVICES=dynamodb
+            - DEBUG=1
+            - LS_LOG=trace # This option adds lots of logging, specifically the API calls made to dynamodb
+            - DOCKER_HOST=unix:///var/run/docker.sock
+            - HOST_TMP_FOLDER=/tmp/localstack
+        volumes:
+            - "/tmp/localstack:/tmp/localstack"
+            - "/var/run/docker.sock:/var/run/docker.sock"
+        networks:
+            spectre_net:
+                ipv4_address: 10.5.0.10
 
     test:
         build:

--- a/itest/docker-compose.yml
+++ b/itest/docker-compose.yml
@@ -23,7 +23,6 @@ services:
             - AWS_ACCESS_KEY_ID=TEST
             - AWS_SECRET_ACCESS_KEY=TEST
             - AWS_DEFAULT_REGION=local-stack
-            - DYNAMO_NAME=local-stack
             - DYNAMO_ENDPOINT=http://10.5.0.10:4566
 
         volumes:
@@ -67,7 +66,6 @@ services:
             - DOCKER_HOST=unix:///var/run/docker.sock
             - HOST_TMP_FOLDER=/tmp/localstack
         volumes:
-            - "/tmp/localstack:/tmp/localstack"
             - "/var/run/docker.sock:/var/run/docker.sock"
         networks:
             spectre_net:

--- a/itest/test/spectre/metrics_test.py
+++ b/itest/test/spectre/metrics_test.py
@@ -151,6 +151,7 @@ def test_bulk_endpoint_miss(log_file):
     response = get_through_spectre(
         '/bulk_requester_2/10,11/v1?foo=bar',
     )
+    time.sleep(1)
     assert response.status_code == 200
     assert response.headers['Spectre-Cache-Status'] == 'miss'
 

--- a/itest/test/spectre/metrics_test.py
+++ b/itest/test/spectre/metrics_test.py
@@ -86,7 +86,7 @@ def _assert_request_timing_metrics(metrics, cache_name):
     }
 
 
-def _assert_fetch_hit_rate(metrics, cache_name):
+def _assert_fetch_hit_rate(metrics, cache_name, backend):
     assert len(metrics) == 2
     assert metrics[0].dimensions == {
         'metric_name': 'spectre.fetch_body_and_headers',
@@ -96,6 +96,7 @@ def _assert_fetch_hit_rate(metrics, cache_name):
         'instance_name': 'itest',
         'cache_name': cache_name,
         'cache_status': 'miss',
+        'backend': backend
     }
 
     assert metrics[1].dimensions == {
@@ -105,11 +106,13 @@ def _assert_fetch_hit_rate(metrics, cache_name):
         'namespace': 'backend.main',
         'instance_name': 'itest',
         'cache_name': cache_name,
-        'cache_status': 'miss'
+        'cache_status': 'miss',
+        'backend': backend
     }
 
 
-def _assert_store_metric(metric, cache_name):
+def _assert_store_metric(metric, cache_name, backend):
+
     assert metric.dimensions == {
         'metric_name': 'spectre.store_body_and_headers',
         'habitat': 'uswest1a',
@@ -117,6 +120,7 @@ def _assert_store_metric(metric, cache_name):
         'namespace': 'backend.main',
         'instance_name': 'itest',
         'cache_name': cache_name,
+        'backend': backend
     }
 
 
@@ -130,11 +134,14 @@ def test_cache_miss(log_file):
 
     metrics = _load_metrics(log_file)
 
+    # We need to know if the backend is DynamoDB or Cassandra
+    backend = metrics[0].dimensions['backend']
+
     # First 2 metrics are `spectre.fetch_body_and_headers` and `spectre.hit_rate`
-    _assert_fetch_hit_rate(metrics[0:2], 'timestamp')
+    _assert_fetch_hit_rate(metrics[0:2], 'timestamp', backend)
 
     # Then since it's a miss we have a `spectre.store_body_and_headers`
-    _assert_store_metric(metrics[2], 'timestamp')
+    _assert_store_metric(metrics[2], 'timestamp', backend)
 
     # Finally the `spectre.request_timing`
     _assert_request_timing_metrics(metrics[3:7], 'timestamp')
@@ -151,20 +158,23 @@ def test_bulk_endpoint_miss(log_file):
     response = get_through_spectre(
         '/bulk_requester_2/10,11/v1?foo=bar',
     )
+
     time.sleep(1)
     assert response.status_code == 200
     assert response.headers['Spectre-Cache-Status'] == 'miss'
 
     metrics = _load_metrics(log_file)
+    # We need to know if the backend is dynamodb or cassandra
+    backend = metrics[0].dimensions['backend']
 
     # We have `spectre.fetch_body_and_headers` and `spectre.hit_rate` twice
     # since we have 2 ids in the url.
-    _assert_fetch_hit_rate(metrics[0:2], 'bulk_requester_default')
-    _assert_fetch_hit_rate(metrics[2:4], 'bulk_requester_default')
+    _assert_fetch_hit_rate(metrics[0:2], 'bulk_requester_default', backend)
+    _assert_fetch_hit_rate(metrics[2:4], 'bulk_requester_default', backend)
 
     # Then we have 2 `spectre.store_body_and_headers`
-    _assert_store_metric(metrics[4], 'bulk_requester_default')
-    _assert_store_metric(metrics[5], 'bulk_requester_default')
+    _assert_store_metric(metrics[4], 'bulk_requester_default', backend)
+    _assert_store_metric(metrics[5], 'bulk_requester_default', backend)
 
     # Then the `spectre.request_timing`
     _assert_request_timing_metrics(metrics[6:10], 'bulk_requester_default')
@@ -196,11 +206,13 @@ def test_no_cache_header_metrics(log_file):
     assert response.status_code == 200
 
     metrics = _load_metrics(log_file)
+    # We need to know if the backend is dynamodb or cassandra
+    backend = metrics[0].dimensions['backend']
 
     # Since we send the no-cache header we don't have a `spectre.fetch_body_and_headers`
     # or `spectre.hit_rate`. We still update the cache though, so we have the
     # `spectre.store_body_and_headers`
-    _assert_store_metric(metrics[0], 'timestamp')
+    _assert_store_metric(metrics[0], 'timestamp', backend)
 
     # Finally we emit the `spectre.no_cache_header`
     assert metrics[1].dimensions == {

--- a/itest/test/util.py
+++ b/itest/test/util.py
@@ -54,6 +54,7 @@ def assert_is_in_spectre_cache(*args, **kwargs):
         if response.headers['Spectre-Cache-Status'] == 'hit':
             return response
         else:
+            time.sleep(0.1)
             continue
     raise AssertionError(
         "No hit after {num_attempts} attempts (headers: '{headers}')".format(

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -536,13 +536,13 @@ end
 
 
 -- Deterministically calculates whether the dynamodb backend is enabled for a given cache item
--- Uses the "dynamodb_enabled" percentage value when making the decision
+-- Uses the "dynamodb_enabled_pct" value when making the decision
 local function is_dynamodb_enabled(cache_key)
 
     local spectre_config = config_loader.get_spectre_config_for_namespace(
         config_loader.CASPER_INTERNAL_NAMESPACE
     )
-    local dynamodb_percent = spectre_config['dynamodb_enabled']
+    local dynamodb_percent = spectre_config['dynamodb_enabled_pct']
 
     -- Take first 7 characters of the hash, as we want to get a 32bit number
     local hash = ngx.md5(cache_key):sub(1, 7)
@@ -639,7 +639,7 @@ local function purge_cache(cassandra_helper, namespace, cache_name, id)
     local spectre_config = config_loader.get_spectre_config_for_namespace(
         config_loader.CASPER_INTERNAL_NAMESPACE
     )
-    local dynamodb_percent = spectre_config['dynamodb_enabled']
+    local dynamodb_percent = spectre_config['dynamodb_enabled_pct']
 
     -- purge dynamodb
     if dynamodb_percent > 0 then

--- a/lua/spectre_common.lua
+++ b/lua/spectre_common.lua
@@ -542,7 +542,7 @@ local function is_dynamodb_enabled(cache_key)
     local spectre_config = config_loader.get_spectre_config_for_namespace(
         config_loader.CASPER_INTERNAL_NAMESPACE
     )
-    local dynamodb_percent = spectre_config['dynamodb_enabled_pct']
+    local dynamodb_percent = spectre_config['dynamodb_enabled_pct'] or 0
 
     -- Take first 7 characters of the hash, as we want to get a 32bit number
     local hash = ngx.md5(cache_key):sub(1, 7)
@@ -639,7 +639,7 @@ local function purge_cache(cassandra_helper, namespace, cache_name, id)
     local spectre_config = config_loader.get_spectre_config_for_namespace(
         config_loader.CASPER_INTERNAL_NAMESPACE
     )
-    local dynamodb_percent = spectre_config['dynamodb_enabled_pct']
+    local dynamodb_percent = spectre_config['dynamodb_enabled_pct'] or 0
 
     -- purge dynamodb
     if dynamodb_percent > 0 then

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -19,11 +19,11 @@ use serde_json::{json, Value as JsonValue};
 use tower::make::Shared;
 
 use casper_runtime::{
-    backends::DynamoDbCacheClient,
+    backends::DynamodDbBackend,
     storage::{Item, ItemKey, Storage},
 };
 
-static BACKEND: Lazy<DynamoDbCacheClient> = Lazy::new(DynamoDbCacheClient::new);
+static BACKEND: Lazy<DynamodDbBackend> = Lazy::new(DynamodDbBackend::new);
 
 #[derive(serde::Deserialize)]
 struct MethodArg<'a> {

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -19,15 +19,11 @@ use serde_json::{json, Value as JsonValue};
 use tower::make::Shared;
 
 use casper_runtime::{
-    backends::{MemoryBackend, MemoryBackendConfig},
+    backends::DynamoDbCacheClient,
     storage::{Item, ItemKey, Storage},
 };
 
-static BACKEND: Lazy<MemoryBackend> = Lazy::new(|| {
-    MemoryBackend::new(&MemoryBackendConfig {
-        max_size: 1024 * 1024 * 1024, // 1 GB
-    })
-});
+static BACKEND: Lazy<DynamoDbCacheClient> = Lazy::new(DynamoDbCacheClient::new);
 
 #[derive(serde::Deserialize)]
 struct MethodArg<'a> {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -29,3 +29,10 @@ anyhow = "1"
 num_cpus = "1.13"
 regex = "1.5"
 linked-hash-map = "0.5.4"
+
+# dynamodb requirements
+rusoto_core = "0.47.0"
+rusoto_dynamodb = "0.47.0"
+chrono = "0.4"
+openssl = { version = "0.10", features = ["vendored"] }
+hex = "0.4.3"

--- a/runtime/casper.toml
+++ b/runtime/casper.toml
@@ -6,5 +6,5 @@ listen = "0.0.0.0:8888"
 code = "require('lua.test')"
 
 [storage.memory]
-backend = "memory"
+backend = "dynamodb"
 capacity = 100

--- a/runtime/src/backends/dynamodb.rs
+++ b/runtime/src/backends/dynamodb.rs
@@ -316,7 +316,6 @@ impl DynamoDbCacheClient {
                 record_expired = true;
             }
         }
-        println!("Cache record expired? : {:?}", record_expired);
 
         if !record_expired {
             // Extract the response headers, body and status code

--- a/runtime/src/backends/dynamodb.rs
+++ b/runtime/src/backends/dynamodb.rs
@@ -1,3 +1,4 @@
+use crate::storage::{Item, ItemKey, Storage};
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -11,11 +12,7 @@ use rusoto_dynamodb::{
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, env};
 
-extern crate flexbuffers;
-
-use crate::storage::{Item, ItemKey, Storage};
-
-pub struct DynamoDbCacheClient {
+pub struct DynamodDbBackend {
     connector: DynamoDbClient,
     cache_key_name: String,
     cache_resp_headers_name: String,
@@ -28,14 +25,14 @@ pub struct DynamoDbCacheClient {
     cache_table_name: String,
 }
 
-impl Default for DynamoDbCacheClient {
+impl Default for DynamodDbBackend {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl DynamoDbCacheClient {
-    pub fn new() -> DynamoDbCacheClient {
+impl DynamodDbBackend {
+    pub fn new() -> DynamodDbBackend {
         let connector;
 
         // Setup a local-stack based client
@@ -50,7 +47,7 @@ impl DynamoDbCacheClient {
             connector = DynamoDbClient::new(Region::default());
         }
 
-        DynamoDbCacheClient {
+        DynamodDbBackend {
             connector,
             cache_key_name: String::from("key"),
             cache_resp_headers_name: String::from("response_headers"),
@@ -368,7 +365,7 @@ impl DynamoDbCacheClient {
 }
 
 #[async_trait]
-impl Storage for DynamoDbCacheClient {
+impl Storage for DynamodDbBackend {
     type Body = hyper::Body;
     type Error = anyhow::Error;
 

--- a/runtime/src/backends/dynamodb.rs
+++ b/runtime/src/backends/dynamodb.rs
@@ -1,0 +1,432 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use bytes::Bytes;
+use core::borrow::BorrowMut;
+use hyper::{HeaderMap, Response, StatusCode};
+use rusoto_core::{Region, RusotoError};
+use rusoto_dynamodb::{
+    AttributeValue, DeleteItemError, DeleteItemInput, DeleteItemOutput, DynamoDb, DynamoDbClient,
+    GetItemError, GetItemInput, GetItemOutput, PutItemError, PutItemInput, PutItemOutput,
+};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{collections::HashMap, env};
+
+extern crate flexbuffers;
+
+use crate::storage::{Item, ItemKey, Storage};
+
+pub struct DynamoDbCacheClient {
+    connector: DynamoDbClient,
+    cache_key_name: String,
+    cache_resp_headers_name: String,
+    cache_resp_body_name: String,
+    cache_resp_status_name: String,
+    cache_surrogate_keys_name: String,
+    cache_creation_ts_name: String,
+    cache_expiry_ts_name: String,
+    sk_timestamp_name: String,
+    cache_table_name: String,
+}
+
+impl Default for DynamoDbCacheClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DynamoDbCacheClient {
+    pub fn new() -> DynamoDbCacheClient {
+        DynamoDbCacheClient {
+            connector: DynamoDbClient::new(Region::Custom {
+                name: env::var("DYNAMO_NAME").unwrap(),
+                endpoint: env::var("DYNAMO_ENDPOINT").unwrap(),
+            }),
+            cache_key_name: String::from("key"),
+            cache_resp_headers_name: String::from("response_headers"),
+            cache_resp_body_name: String::from("response_body"),
+            cache_resp_status_name: String::from("response_status_code"),
+            cache_surrogate_keys_name: String::from("surrogate_keys"),
+            cache_creation_ts_name: String::from("creation_timestamp"),
+            cache_expiry_ts_name: String::from("expiry_timestamp"),
+            sk_timestamp_name: String::from("sk_timestamp"),
+            cache_table_name: env::var("DYNAMO_TABLE")
+                .unwrap_or_else(|_| String::from("casper_cache")),
+        }
+    }
+
+    async fn get_item(
+        &self,
+        key: Vec<u8>,
+        projection_expression: Option<String>,
+    ) -> Result<GetItemOutput, RusotoError<GetItemError>> {
+        let attribute_value_key = AttributeValue {
+            b: Option::Some(Bytes::from(key)),
+            ..Default::default()
+        };
+
+        let mut get_item = HashMap::new();
+        get_item.insert(self.cache_key_name.clone(), attribute_value_key);
+
+        let get_item_input = GetItemInput {
+            key: get_item,
+            table_name: self.cache_table_name.clone(),
+            projection_expression,
+            consistent_read: Some(true),
+            ..Default::default()
+        };
+
+        self.connector.get_item(get_item_input).await
+    }
+
+    async fn delete_item(
+        &self,
+        key: Vec<u8>,
+    ) -> Result<DeleteItemOutput, RusotoError<DeleteItemError>> {
+        let attribute_value_key = AttributeValue {
+            b: Option::Some(Bytes::from(key)),
+            ..Default::default()
+        };
+        let mut delete_item = HashMap::new();
+        delete_item.insert(self.cache_key_name.clone(), attribute_value_key);
+
+        let delete_item_input = DeleteItemInput {
+            table_name: self.cache_table_name.clone(),
+            key: delete_item,
+            ..Default::default()
+        };
+        self.connector.delete_item(delete_item_input).await
+    }
+
+    fn serialize_headers(&self, headers: &HeaderMap) -> Vec<u8> {
+        // Serializes the headers in the flexbuffer format
+        flexbuffers::to_vec(&hyper_serde::Ser::new(headers)).unwrap()
+    }
+
+    fn deserialize_headers(&self, data: &[u8]) -> HeaderMap {
+        // Deserializes the headers from the flexbuffer format
+        let headers: hyper_serde::De<HeaderMap> = flexbuffers::from_slice(data).unwrap();
+        headers.into_inner()
+    }
+
+    async fn cache_response(
+        &self,
+        key: &[u8],
+        response: &mut Response<hyper::Body>,
+        surrogate_keys: Vec<Vec<u8>>,
+        ttl_duration: Option<Duration>,
+    ) -> Result<()> {
+        // Get the response body, serialize headers etc
+        let resp_body = hyper::body::to_bytes(response.body_mut())
+            .await
+            .unwrap()
+            .to_vec();
+        let headers = response.headers();
+        let s_resp_headers = self.serialize_headers(headers);
+        let status = response.status().as_u16();
+
+        // ttl expiry is Unix timestamp now + ttl
+        let ttl_expire_ts = (SystemTime::now() + ttl_duration.unwrap())
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // Create the attribute values for the put item
+        let mut av_key: AttributeValue = Default::default();
+        let mut av_resp_headers: AttributeValue = Default::default();
+        let mut av_resp_body: AttributeValue = Default::default();
+        let mut av_resp_status: AttributeValue = Default::default();
+        let mut av_sks: AttributeValue = Default::default();
+        let mut av_creation_ts: AttributeValue = Default::default();
+        let mut av_expiry_ts: AttributeValue = Default::default();
+
+        // Create a vector of attributes for surrogate_keys
+        let mut sk_av_vec: Vec<AttributeValue> = vec![];
+        for sk in surrogate_keys.clone() {
+            let av_sk = AttributeValue {
+                b: Option::Some(Bytes::from(sk)),
+                ..Default::default()
+            };
+            sk_av_vec.push(av_sk);
+        }
+
+        // Add creation timestamp for response record
+        let unix_ts_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // Set attribute value contents
+        av_key.b = Option::Some(Bytes::from(key.to_vec()));
+        av_resp_headers.b = Option::Some(Bytes::from(s_resp_headers));
+        av_resp_body.b = Option::Some(Bytes::from(resp_body));
+        av_resp_status.n = Option::Some(status.to_string());
+        av_sks.l = Option::Some(sk_av_vec);
+        av_creation_ts.n = Option::Some(unix_ts_now.to_string());
+        av_expiry_ts.n = Option::Some(ttl_expire_ts.to_string());
+
+        // Create a PutItem using above attribute values
+        let mut item = HashMap::new();
+        item.insert(self.cache_key_name.clone(), av_key);
+        item.insert(self.cache_resp_headers_name.clone(), av_resp_headers);
+        item.insert(self.cache_resp_body_name.clone(), av_resp_body);
+        item.insert(self.cache_resp_status_name.clone(), av_resp_status);
+        item.insert(self.cache_surrogate_keys_name.clone(), av_sks);
+        item.insert(self.cache_creation_ts_name.clone(), av_creation_ts);
+        item.insert(self.cache_expiry_ts_name.clone(), av_expiry_ts);
+
+        let put_item = PutItemInput {
+            item,
+            table_name: self.cache_table_name.clone(),
+            ..Default::default()
+        };
+
+        // put the response item / records
+        self.connector.put_item(put_item).await?;
+
+        // put / update the surrogate key items / records
+        for sk in surrogate_keys {
+            // Currently setting the DynamoDB expiry to now + 24 hours
+            self.update_surrogate_item(sk, false).await?;
+        }
+        Ok(())
+    }
+
+    async fn update_surrogate_item(&self, key: Vec<u8>, invalidate: bool) -> Result<()> {
+        // Check if surrogate_key already exists
+        let sk_item_output = self
+            .get_item(key.clone(), Some(self.sk_timestamp_name.to_string()))
+            .await?;
+        let sk_item = sk_item_output.item.as_ref();
+
+        let mut sk_ts: u64;
+        if sk_item.is_none() {
+            // No surrogate key exists, set initial sk_timestamp to 0
+            sk_ts = 0;
+        } else {
+            // If exists, store the existing sk timestamp value
+            let sk_ts_av = sk_item.unwrap().get(&self.sk_timestamp_name).unwrap();
+            sk_ts = sk_ts_av.n.clone().unwrap().parse::<u64>().unwrap();
+        }
+
+        // Expiry timestamp set to now + 24 hours
+        let exp_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 86400;
+
+        // If the invalidate flag is set, sk_timestamp is overwritten to now()
+        if invalidate {
+            sk_ts = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+        }
+        self.put_surrogate_item(key, sk_ts, exp_ts).await?;
+        Ok(())
+    }
+    async fn put_surrogate_item(
+        &self,
+        key: Vec<u8>,
+        sk_ts: u64,
+        exp_ts: u64,
+    ) -> Result<PutItemOutput, RusotoError<PutItemError>> {
+        let mut av_key: AttributeValue = Default::default();
+        let mut av_timestamp: AttributeValue = Default::default();
+        let mut av_expiry_ts: AttributeValue = Default::default();
+
+        av_key.b = Option::Some(Bytes::from(key.to_vec()));
+        av_timestamp.n = Option::Some(sk_ts.to_string());
+        av_expiry_ts.n = Option::Some(exp_ts.to_string());
+
+        // Create a PutItem using above attribute values
+        let mut item = HashMap::new();
+        item.insert(self.cache_key_name.clone(), av_key);
+        item.insert(self.sk_timestamp_name.clone(), av_timestamp);
+        item.insert(self.cache_expiry_ts_name.clone(), av_expiry_ts);
+
+        let put_item = PutItemInput {
+            item,
+            table_name: self.cache_table_name.clone(),
+            ..Default::default()
+        };
+
+        self.connector.put_item(put_item).await
+    }
+
+    async fn get_cached_response(&self, key: &[u8]) -> Option<Response<hyper::Body>> {
+        // Filter on required values only
+        let projection_expression = Some(format!(
+            "{},{},{},{},{},{}",
+            self.cache_resp_body_name,
+            self.cache_resp_headers_name,
+            self.cache_resp_status_name,
+            self.cache_creation_ts_name,
+            self.cache_expiry_ts_name,
+            self.cache_surrogate_keys_name
+        ));
+
+        // Get the GetItemOutput object
+        let item_output = self
+            .get_item(key.to_vec(), projection_expression)
+            .await
+            .unwrap();
+
+        // If we don't get an item back from dynamoDB return None
+        item_output.item.as_ref()?;
+
+        let item = item_output.item.unwrap();
+
+        // Get the response creation and TTL timestamps before doing anything else
+        let av_creation_ts = item.get(&self.cache_creation_ts_name).unwrap();
+        let creation_ts = av_creation_ts.n.clone()?.parse::<u64>().unwrap();
+
+        // Because the dynamoDB item expiry can take some time, check the current time against the item TTL
+        let av_expiry_ts = item.get(&self.cache_expiry_ts_name).unwrap();
+        let av_expiry_ts_extracted = av_expiry_ts.n.clone()?.parse::<u64>().unwrap();
+        let now_unix_ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // If record is expired return None
+        if now_unix_ts > av_expiry_ts_extracted {
+            return None;
+        }
+
+        //Get the surrogate keys, as we need to check these first to see if the record is valid (or expired)
+        let av_sks = item.get(&self.cache_surrogate_keys_name).unwrap();
+        let sks_extracted = av_sks.l.clone().unwrap();
+        let mut record_expired = false;
+
+        for sk in sks_extracted {
+            let sk = sk.b.unwrap().to_vec();
+
+            // Get the surrogate key record, filter on the timestamp value only
+            let projection_expression = Some(self.sk_timestamp_name.to_string());
+
+            let sk_item = self.get_item(sk, projection_expression).await.unwrap();
+            let sk_item_avs = sk_item.item.as_ref()?;
+            let av_sk_item_ts = sk_item_avs.get(&self.sk_timestamp_name)?;
+
+            // Convert the record number string into a u64 value
+            let sk_ts = av_sk_item_ts.n.clone()?.parse::<u64>().unwrap();
+
+            if creation_ts < sk_ts {
+                record_expired = true;
+            }
+        }
+        println!("Cache record expired? : {:?}", record_expired);
+
+        if !record_expired {
+            // Extract the response headers, body and status code
+            let av_resp_headers = item.get(&self.cache_resp_headers_name)?;
+            let av_resp_body = item.get(&self.cache_resp_body_name)?;
+            let av_resp_status = item.get(&self.cache_resp_status_name)?;
+
+            let resp_headers_extracted = av_resp_headers.b.as_ref();
+            let resp_body_extracted = av_resp_body.b.clone()?;
+            let resp_status_extracted = av_resp_status.clone().n?;
+
+            // Deserialize the response headers
+            let resp_headers_vec = resp_headers_extracted.unwrap().as_ref();
+            let d_resp_headers = self.deserialize_headers(resp_headers_vec);
+
+            // Convert the body into a hyper::Body
+            let resp_hyper_body = hyper::Body::from(resp_body_extracted);
+
+            // Construct a response object
+            let mut constructed_resp = Response::builder().body(resp_hyper_body).unwrap();
+
+            // Dereference the response headers and set the value to that of the deserialized headers
+            *constructed_resp.headers_mut() = d_resp_headers;
+
+            // Construct a StatusCode object and set it as the value for the Response status
+            let status_code_u16: u16 = resp_status_extracted.parse().unwrap();
+            let status = StatusCode::from_u16(status_code_u16).unwrap();
+            *constructed_resp.status_mut() = status;
+            Some(constructed_resp)
+        } else {
+            None
+        }
+    }
+}
+
+#[async_trait]
+impl Storage for DynamoDbCacheClient {
+    type Body = hyper::Body;
+    type Error = anyhow::Error;
+
+    async fn get_responses<K, KI>(
+        &self,
+        keys: KI,
+    ) -> Result<Vec<Option<Response<Self::Body>>>, Self::Error>
+    where
+        KI: IntoIterator<Item = K> + Send,
+        <KI as IntoIterator>::IntoIter: Send,
+        K: AsRef<[u8]> + Send,
+    {
+        let mut result = Vec::new();
+        for key in keys {
+            // Currently calling the single get cached response method per key, but eventually need to
+            // implement bulk get items
+            let key = key.as_ref();
+            let resp = self.get_cached_response(key).await;
+            result.push(resp);
+        }
+        Ok(result)
+    }
+
+    async fn delete_responses<K, KI>(&self, keys: KI) -> Result<(), Self::Error>
+    where
+        KI: IntoIterator<Item = ItemKey<K>> + Send,
+        <KI as IntoIterator>::IntoIter: Send,
+        K: AsRef<[u8]> + Send,
+    {
+        for key in keys {
+            match key {
+                ItemKey::Primary(key) => {
+                    let d_key = key.as_ref().to_vec();
+                    self.delete_item(d_key.clone()).await?;
+                }
+                ItemKey::Surrogate(sk) => {
+                    let s_key = sk.as_ref().to_vec();
+                    self.update_surrogate_item(s_key.clone(), true).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn cache_responses<K, R, SK, I>(&self, items: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Item<K, R, SK>> + Send,
+        <I as IntoIterator>::IntoIter: Send,
+        K: AsRef<[u8]> + Send,
+        R: BorrowMut<Response<Self::Body>> + Send,
+        SK: AsRef<[u8]> + Send,
+    {
+        for mut it in items {
+            // Extract the item components
+            let key = it.key.as_ref();
+            let resp = it.response.borrow_mut();
+            let ttl = it.ttl;
+            let sk = it
+                .surrogate_keys
+                .into_iter()
+                .map(|x| x.as_ref().to_vec())
+                .collect();
+
+            // Call cache response with extracted components
+            let _res = self.cache_response(key, resp, sk, ttl).await;
+            let _res = match _res {
+                Ok(_res) => _res,
+                Err(error) => panic!(
+                    "Error when trying to cache item with key: {:?} error: {}",
+                    key, error
+                ),
+            };
+        }
+        Ok(())
+    }
+}

--- a/runtime/src/backends/mod.rs
+++ b/runtime/src/backends/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, Context};
 use once_cell::sync::OnceCell;
 
-pub use dynamodb::DynamoDbCacheClient;
+pub use dynamodb::DynamodDbBackend;
 pub use memory::Config as MemoryBackendConfig;
 pub use memory::MemoryBackend;
 

--- a/runtime/src/backends/mod.rs
+++ b/runtime/src/backends/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, Context};
 use once_cell::sync::OnceCell;
 
+pub use dynamodb::DynamoDbCacheClient;
 pub use memory::Config as MemoryBackendConfig;
 pub use memory::MemoryBackend;
 
@@ -48,4 +49,5 @@ pub fn registered_backends() -> &'static HashMap<String, Backend> {
         .expect("register_backends() must be called first")
 }
 
+mod dynamodb;
 mod memory;


### PR DESCRIPTION
**This code is a proof of concept, there are many production ready improvements that are required.**

**This PR includes:**

- The backend DynamoDB code utilising Rusoto
- Adjustments to the plugin code to use this backend, instead of using the memory backend
- Integration test additions to include a localstack instance, create the initial casper table etc, which is required to run the tests
- The addition of sleeps to the Python Integration tests, ultimately to avoid race conditions which cause the tests to fail, but won't be problems in the real world. Longer term we need a better more deterministic way of solving this.
- A mechanism to configure the percentage of traffic which is directed to the DynamoDB backend vs the Cassandra backend
- Connector setup logic to support both AWS and localstack (itest)
- Added a backend dimension to some of the fetch and store related performance metrics, this will allow performance comparisons between the different backends

Backend selection code was tested with the following selection values during integration tests and counts the number of records in the DynamoDB instance (max 108 items).
```
with dynamodb_enabled: 0 -   Count: 0
with dynamodb_enabled: 1 -   Count: 12
with dynamodb_enabled: 25 -  Count: 29
with dynamodb_enabled: 50 -  Count: 53
with dynamodb_enabled: 75 -  Count: 79
with dynamodb_enabled: 100 - Count: 108
```
