### PR TITLE
Add cache_status to emit_request_timing

### DIFF
--- a/tests/lua/metrics_helper_test.lua
+++ b/tests/lua/metrics_helper_test.lua
@@ -68,22 +68,22 @@ describe("metrics_helper", function()
         }
 
         local metrics_helper = require 'metrics_helper'
-        metrics_helper.emit_request_timing(1, 'some.namespace', 'test_cache', 200)
+        metrics_helper.emit_request_timing(1, 'some.namespace', 'test_cache', 200, 'hit')
 
         assert.are_equal(
-            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "some.namespace"],["cache_name", "test_cache"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "some.namespace"],["cache_name", "test_cache"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
             spy_send.calls[1]['vals'][2] -- 2nd argument of the first call
         )
         assert.are_equal(
-            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "__ALL__"],["cache_name", "test_cache"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "__ALL__"],["cache_name", "test_cache"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
             spy_send.calls[2]['vals'][2] -- 2nd argument of the second call
         )
         assert.are_equal(
-            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "some.namespace"],["cache_name", "__ALL__"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "some.namespace"],["cache_name", "__ALL__"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
             spy_send.calls[3]['vals'][2] -- 2nd argument of the third call
         )
         assert.are_equal(
-            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "__ALL__"],["cache_name", "__ALL__"],["status", "200"],["metric_name", "spectre.request_timing"]]:1|ms',
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "__ALL__"],["cache_name", "__ALL__"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
             spy_send.calls[4]['vals'][2] -- 2nd argument of the fourth call
         )
     end)


### PR DESCRIPTION
Adds `cache_status` (hit or miss) to the request timing metrics dimensions, allowing us to differentiate between the request timings for both cached and non cached (forwarded to downstream) requests.