### PR TITLE
Add latency and hit rate metrics for V2

### DIFF
--- a/tests/lua/metrics_helper_test.lua
+++ b/tests/lua/metrics_helper_test.lua
@@ -71,19 +71,19 @@ describe("metrics_helper", function()
         metrics_helper.emit_request_timing(1, 'some.namespace', 'test_cache', 200, 'hit')
 
         assert.are_equal(
-            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "some.namespace"],["cache_name", "test_cache"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["casper_version", "v1"],["namespace", "some.namespace"],["cache_name", "test_cache"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
             spy_send.calls[1]['vals'][2] -- 2nd argument of the first call
         )
         assert.are_equal(
-            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "__ALL__"],["cache_name", "test_cache"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["casper_version", "v1"],["namespace", "__ALL__"],["cache_name", "test_cache"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
             spy_send.calls[2]['vals'][2] -- 2nd argument of the second call
         )
         assert.are_equal(
-            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "some.namespace"],["cache_name", "__ALL__"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["casper_version", "v1"],["namespace", "some.namespace"],["cache_name", "__ALL__"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
             spy_send.calls[3]['vals'][2] -- 2nd argument of the third call
         )
         assert.are_equal(
-            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["namespace", "__ALL__"],["cache_name", "__ALL__"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
+            '[["habitat", "uswest1a"],["service_name", "spectre"],["instance_name", "test"],["casper_version", "v1"],["namespace", "__ALL__"],["cache_name", "__ALL__"],["status", "200"],["cache_status", "hit"],["metric_name", "spectre.request_timing"]]:1|ms',
             spy_send.calls[4]['vals'][2] -- 2nd argument of the fourth call
         )
     end)


### PR DESCRIPTION
Currently added `spectre.hit_rate` and `spectre.request_timing` as I think these are the most valuable metrics. Can add the store/fetch metrics, although these are more for internal monitoring (and we have other V2 metrics).

Added back metrics integration tests, although trying to support V1 and V2 metrics tests means that the test setup is less than ideal and a bit messy at the moment, this could definitely be made better, but I ran out of time this week (and I'm not sure if its worth spending the time on this, given the eventual move to V2).

Also added a `casper_version` dimension (v1 or v2) so we can filter more easily.