### PR TITLE
Add get_files_in_dir function

### DIFF
--- a/casper-server/src/lua/fs.rs
+++ b/casper-server/src/lua/fs.rs
@@ -25,6 +25,36 @@ async fn get_metadata(lua: &'_ Lua, path: String) -> Result<Table<'_>> {
     Ok(table)
 }
 
+/// Returns a table containing a list of files within a given path
+///
+/// # Arguments
+///
+/// * `path` - A string that contains the path of the directory to read
+async fn get_files_in_dir(lua: &'_ Lua, path: String) -> Result<Table<'_>> {
+    let mut dir_read = tokio::fs::read_dir(path).await?;
+    let table = lua.create_table()?;
+    let mut i = 1;
+    while let Some(dir_entry) = dir_read.next_entry().await? {
+        if dir_entry.metadata().await?.is_file() {
+            let file_string = dir_entry
+                .path()
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+            table.set(i, file_string)?;
+            i += 1;
+        }
+    }
+    Ok(table)
+}
+
 pub fn create_module(lua: &Lua) -> Result<Table> {
-    lua.create_table_from([("get_metadata", lua.create_async_function(get_metadata)?)])
+    lua.create_table_from([
+        ("get_metadata", lua.create_async_function(get_metadata)?),
+        (
+            "get_files_in_dir",
+            lua.create_async_function(get_files_in_dir)?,
+        ),
+    ])
 }


### PR DESCRIPTION
Required for the internal `/status` endpoint populating a list of configured services. This function is then made accessible to the Lua code.
In Lua, this is called as follows:
```
local core = require("core")
local files = core.fs.get_files_in_dir(PATH)
```