### PR TITLE
Increasing the purge timeout to 4s instead of 1s 

### DIFF
--- a/lua/v2_helper.lua
+++ b/lua/v2_helper.lua
@@ -125,8 +125,8 @@ local function purge(namespace, cache_name, id)
 
     local httpc = resty_http.new()
 
-    -- Use a higher timeout for purge calls specifically (2000 rather than 1000)
-    httpc:set_timeout(2000)
+    -- Use a higher timeout for purge calls specifically (4000 rather than 1000)
+    httpc:set_timeout(4000)
 
     local res, err = httpc:request_uri(BACKEND_ADDR, {
         method = "DELETE",

--- a/lua/v2_helper.lua
+++ b/lua/v2_helper.lua
@@ -140,7 +140,11 @@ local function purge(namespace, cache_name, id)
     })
 
     if err ~= nil or res.status ~= 200 then
-        return ngx.HTTP_INTERNAL_SERVER_ERROR, 'Failed to purge some keys. Check spectre logs. ('..(err or "")..')'
+        local message = 'Failed to purge some keys for namespace: ' ..
+              namespace .. ' cache_name: ' .. cache_name ..
+              ' Reason: ' .. (err or "")
+        ngx.log(ngx.ERR, message)
+        return ngx.HTTP_INTERNAL_SERVER_ERROR, message
     end
 
     local response = string.format(

--- a/lua/v2_helper.lua
+++ b/lua/v2_helper.lua
@@ -141,8 +141,9 @@ local function purge(namespace, cache_name, id)
 
     if err ~= nil or res.status ~= 200 then
         local message = 'Failed to purge some keys for namespace: ' ..
-              namespace .. ' cache_name: ' .. cache_name ..
-              ' Reason: ' .. (err or "")
+              namespace .. ', cache_name: ' .. cache_name ..
+              ', id: ' .. (id or "none") ..
+              ', reason: ' .. (err or "")
         ngx.log(ngx.ERR, message)
         return ngx.HTTP_INTERNAL_SERVER_ERROR, message
     end


### PR DESCRIPTION
We've been getting timed out while making connections, increasing the TTL to 4s to see if this helps in reducing the dropped connections. 