### PR TITLE
Add lua log module and functions

### DIFF
--- a/casper-server/src/lua/core.rs
+++ b/casper-server/src/lua/core.rs
@@ -16,6 +16,7 @@ pub fn create_module(lua: &Lua) -> LuaResult<Table> {
     core.set("datetime", super::datetime::create_module(lua)?)?;
     core.set("fs", super::fs::create_module(lua)?)?;
     core.set("json", super::json::create_module(lua)?)?;
+    core.set("log", super::log::create_module(lua)?)?;
     core.set("metrics", super::metrics::create_module(lua)?)?;
     core.set("regex", super::regex::create_module(lua)?)?;
     core.set("tasks", super::tasks::create_module(lua)?)?;

--- a/casper-server/src/lua/log.rs
+++ b/casper-server/src/lua/log.rs
@@ -1,0 +1,45 @@
+use mlua::{Lua, Result, Table};
+use tracing::{error, info, warn};
+
+fn info(_: &'_ Lua, message: String) -> Result<()> {
+    info!(message);
+    Ok(())
+}
+
+fn warn(_: &'_ Lua, message: String) -> Result<()> {
+    warn!(message);
+    Ok(())
+}
+
+fn error(_: &'_ Lua, message: String) -> Result<()> {
+    error!(message);
+    Ok(())
+}
+
+pub fn create_module(lua: &Lua) -> Result<Table> {
+    lua.create_table_from([
+        ("info", lua.create_function(info)?),
+        ("warn", lua.create_function(warn)?),
+        ("error", lua.create_function(error)?),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use mlua::{chunk, Lua, Result};
+
+    #[test]
+    fn test_module() -> Result<()> {
+        let lua = Lua::new();
+
+        let log = super::create_module(&lua)?;
+        lua.load(chunk! {
+            $log.info("test info")
+            $log.warn("test warn")
+            $log.error("test error")
+        })
+        .exec()?;
+
+        Ok(())
+    }
+}

--- a/casper-server/src/lua/mod.rs
+++ b/casper-server/src/lua/mod.rs
@@ -10,6 +10,7 @@ pub mod datetime;
 pub mod fs;
 pub mod http;
 pub mod json;
+pub mod log;
 pub mod metrics;
 pub mod regex;
 pub mod storage;


### PR DESCRIPTION
In the Lua environment this is called as follows:
```
local core = require("core")
local log = core.log

log.info("Log message")
```

Example log output:
```
2022-08-10T12:54:51.205240Z  INFO handler{method=GET uri=/status}: casper_server::lua::log: Success - loading config: {"casper_config":"present" ...}
```