### PR TITLE
Fixes compile error

### DIFF
--- a/casper-server/src/lua/uri.rs
+++ b/casper-server/src/lua/uri.rs
@@ -31,8 +31,8 @@ fn normalize_uri(_: &Lua, uri: LuaString) -> LuaResult<String> {
             // Split query to a list of (k, v) items (where `v` is optional)
             let mut query_pairs = query
                 .split('&')
-                .map(|it| it.splitn(2, '=').collect::<Box<_>>())
-                .collect::<Box<_>>();
+                .map(|it| it.splitn(2, '=').collect::<Vec<&str>>())
+                .collect::<Vec<Vec<&str>>>();
 
             // Sort the list
             query_pairs.sort_by_key(|x| x[0]);
@@ -41,7 +41,7 @@ fn normalize_uri(_: &Lua, uri: LuaString) -> LuaResult<String> {
             let query = query_pairs
                 .iter()
                 .map(|kv| kv.join("="))
-                .collect::<Box<_>>()
+                .collect::<Vec<String>>()
                 .join("&");
 
             parts.path_and_query = Some(format!("{}?{}", path, query).parse().into_lua_err()?)


### PR DESCRIPTION
## Problem

Build fails with the following:

```
Compiling casper-server v0.1.0 (/nail/home/dfallak/.cargo/git/checkouts/casper-b952159e8c9cd1ac/dd54a31/casper-server)
error[E0282]: type annotations needed for `Box<_>`
  --> casper-server/src/lua/uri.rs:32:17
   |
32 |             let mut query_pairs = query
   |                 ^^^^^^^^^^^^^^^
...
38 |             query_pairs.sort_by_key(|x| x[0]);
   |                         ----------- type must be known at this point
   |
help: consider giving `query_pairs` an explicit type, where the placeholders `_` are specified
   |
32 |             let mut query_pairs: Box<_> = query
   |                                ++++++++

For more information about this error, try `rustc --explain E0282`.
error: could not compile `casper-server` (bin "casper-server") due to 1 previous error
```

## Solution

Provide explicit types for the untyped variables.

## Verification

Run `cargo build` in casper-server directory.