### PR TITLE
Removes path from span name to normalize it

### DIFF
--- a/casper-server/src/middleware/trace.rs
+++ b/casper-server/src/middleware/trace.rs
@@ -84,7 +84,7 @@ where
             let connection_info = req.connection_info();
             let span_builder = self
                 .tracer
-                .span_builder(format!("{} {}", req.method(), req.uri().path()))
+                .span_builder(format!("{}", req.method()))
                 .with_kind(trace::SpanKind::Server)
                 .with_attributes([
                     KeyValue::new("request.method", req.method().to_string()),


### PR DESCRIPTION
## Problem or Feature
Casper generates very high cardinality for span names. The service does not perform the mapping from path to endpoint within the service, but instead does the routing from namespace to service. This makes it difficult for it to map a path to a low-cardinality span name.

## Solution
Remove path from span name. URI is still retrievable from the `request.uri` attribute.

