### PR TITLE
Include standard otel attributes

### DIFF
--- a/casper-server/src/trace.rs
+++ b/casper-server/src/trace.rs
@@ -62,7 +62,7 @@ pub fn init(config: &Config) -> Option<SdkTracerProvider> {
 
     if let Some(service_name) = &config.main.service_name {
         provider_builder = provider_builder.with_resource(
-            opentelemetry_sdk::Resource::builder_empty()
+            opentelemetry_sdk::Resource::builder()
                 .with_service_name(service_name.clone())
                 .build(),
         );


### PR DESCRIPTION
Standard otel attributes include [sdk name, language and version](https://github.com/open-telemetry/opentelemetry-rust/blob/5250df2f419b43c4eef0fca4ffb04edd943c61b6/opentelemetry-sdk/src/resource/telemetry.rs#L21-L23).